### PR TITLE
basic_string_view's non-member begin/end should take basic_string_vie…

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1205,11 +1205,11 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    _NODISCARD friend constexpr const_iterator begin(const basic_string_view& _Right) noexcept {
-        // non-member overload that accepts rvalues to model the exposition-only forwarding-range concept
+    _NODISCARD friend constexpr const_iterator begin(basic_string_view _Right) noexcept {
+        // non-member overload to model the exposition-only forwarding-range concept
         return _Right.begin();
     }
-    _NODISCARD friend constexpr const_iterator end(const basic_string_view& _Right) noexcept {
+    _NODISCARD friend constexpr const_iterator end(basic_string_view _Right) noexcept {
         // Ditto modeling forwarding-range
         return _Right.end();
     }


### PR DESCRIPTION
…w by value (#119)

... as the working draft requires. Test coverage failed to detect this issue due to [an overload resolution bug in MSVC](https://developercommunity.visualstudio.com/content/problem/739010/overload-resolution-fails-to-select-deleted-overlo.html).

Drive-by: Remove the "accepts rvalues" bit from the comment in `begin` which caused the confusion that gave rise to #104. Hopefully it is now glaringly obvious that `begin` and `end` accept both lvalues and rvalues.

Resolves #104.

Please note that acceptance of community PRs will be delayed while we are
bringing our test and CI systems online. For more information, see the
README.md.

# Description

# Checklist:

- [ ] I understand README.md.
- [ ] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [ ] Any code files edited have been processed by clang-format 8.0.1.
  (The version is important because clang-format's behavior sometimes changes.)
- [ ] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] Identifiers in test code changes are *not* `_Ugly`.
- [ ] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [ ] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [ ] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
