### PR TITLE
* Replaced Microsoft/STL with microsoft/STL (microsoft#157)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg.git
+	fetchRecurseSubmodules = false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,7 @@ add_compile_definitions(
     _CRT_DECLARE_NONSTDC_NAMES=1 )
 
 # TRANSITION, /analyze ?
-# TRANSITION, /d2FH4- ?
-add_compile_options(/diagnostics:caret /W4 /WX /w14265 /w15038 /d1FastFail /guard:cf /Z7 /d2Zi+ /Gm- /Gy /Zp8 /std:c++latest /permissive- /Zc:threadSafeInit- /d2FH4-)
+add_compile_options(/diagnostics:caret /W4 /WX /w14265 /w15038 /d1FastFail /guard:cf /Z7 /d2Zi+ /Gm- /Gy /Zp8 /std:c++latest /permissive- /Zc:threadSafeInit-)
 
 set(VCLIBS_DEBUG_OPTIONS "/Od")
 set(VCLIBS_RELEASE_FLAGS "/O2;/Os") # TRANSITION: Potentially remove /Os

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ acquire this dependency.
    and ARM64.
 6. Run `.\vcpkg.exe integrate install` which tells Visual Studio which vcpkg instance you wish to use. If you have never
    done this before, you may be prompted to elevate.
-7. Open Visual Studio 2019 16.3 or later, and choose the "Clone or check out code" option. Enter the URI to this
+7. Open Visual Studio 2019 16.3 or later, and choose the "Clone or check out code" option. Enter the URL to this
    repository, typically `https://github.com/Microsoft/STL`
 8. Choose the architecture you wish to build in the IDE, and build as you would any other project. All necessary CMake
    settings are set by `CMakeSettings.json` and `vcpkg integrate`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This is the official repository for Microsoft's implementation of the C++ Standard Library (also known as the STL),
 which ships as part of the MSVC toolset and the Visual Studio IDE.
 
+[![Build Status](https://dev.azure.com/vclibs/STL/_apis/build/status/microsoft.STL?branchName=master)][Pipelines]
+
 # What This Repo Is Useful For
 
 If you're a programmer who just wants to use the STL, you **don't** need this repo. Simply install the Visual Studio IDE
@@ -258,6 +260,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [N4830]: https://wg21.link/n4830
 [NOTICE.txt]: NOTICE.txt
 [Ninja]: https://ninja-build.org
+[Pipelines]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=2&branchName=master
 [Roadmap]: https://github.com/microsoft/STL/wiki/Roadmap
 [Wandbox]: https://wandbox.org
 [bug tag]: https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3Abug

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ soon as possible.)
 * Tests: **Coming soon.** We rely on three test suites: devcrt, tr1, and [libcxx][]. We need to replace our current test
 harness, which extensively uses Microsoft-internal machinery.
 
-* Continuous Integration: **Coming soon.** We need tests first.
+* Continuous Integration: **In progress.** We've set up Azure Pipelines to validate changes to the repository.
+However, that infrastructure requires manual review before building community-submitted pull requests, as we haven't
+yet hardened it against untrusted changes.
 
 * Contribution Guidelines: **Coming soon.** Working on the STL's code involves following many rules. We have codebase
 conventions, Standard requirements, Microsoft-specific requirements, binary compatibility (ABI) requirements, and more.

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ mention `std::` or C++. For example, "`<type_traits>`: `is_cute` should be true 
 It's okay if you report an apparent STL bug that turns out to be a compiler bug, or surprising-yet-Standard behavior.
 Just try to follow these rules, so we can spend more time fixing bugs and implementing features.
 
-# How to Build with the Visual Studio IDE
+# How To Build With The Visual Studio IDE
 
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
 1. Install Visual Studio 2019 16.3 or later.
-2. Invoke `git clone https://github.com/Microsoft/vcpkg`
+2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`
 5. Assuming you are targeting x86 and x64, invoke `.\vcpkg.exe install boost-math:x86-windows boost-math:x64-windows`
@@ -149,30 +149,30 @@ acquire this dependency.
 6. Run `.\vcpkg.exe integrate install` which tells Visual Studio which vcpkg instance you wish to use. If you have never
    done this before, you may be prompted to elevate.
 7. Open Visual Studio 2019 16.3 or later, and choose the "Clone or check out code" option. Enter the URL to this
-   repository, typically `https://github.com/Microsoft/STL`
+   repository, typically `https://github.com/microsoft/STL`
 8. Choose the architecture you wish to build in the IDE, and build as you would any other project. All necessary CMake
    settings are set by `CMakeSettings.json` and `vcpkg integrate`
 
-# How to Build with a Native Tools Command Prompt
+# How To Build With A Native Tools Command Prompt
 
 These instructions assume you're targeting `x64-windows`; you can change this constant below to target other
 architectures.
 
 1. Install [CMake][] 3.15 or later, [Ninja][] 1.8.2 or later, and Visual Studio 2019 16.3 or later.
-2. Invoke `git clone https://github.com/Microsoft/vcpkg`
+2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`
 5. Invoke `.\vcpkg.exe install boost-math:x64-windows` to install the boost-math dependency.
 6. Open an "x64 Native Tools Command Prompt for VS 2019".
 7. Change directories to a location where you'd like a clone of this STL repository.
-8. Invoke `git clone https://github.com/Microsoft/STL`
+8. Invoke `git clone https://github.com/microsoft/STL`
 9. Invoke `cd STL`
 10. Invoke `cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE={where your vcpkg clone is located}\scripts\buildsystems\vcpkg.cmake
 -S . -B {wherever you want binaries}` to configure the project. For example,
 `cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=C:\Dev\vcpkg\scripts\buildsystems\vcpkg.cmake -S . -B build.x64`
 11. Invoke `ninja -C {wherever you want binaries}` to build the project. For example, `ninja -C build.x64`
 
-# How to Consume
+# How To Consume
 
 Consumption of the built library is largely based on the build system you're using. There are at least 2 directories
 you need to hook up. Assuming you built the x64 target with the Visual Studio IDE, with the STL repository cloned to
@@ -188,7 +188,7 @@ ensures that other components wanting to be a "guest in your process", like prin
 export surface of the STL they were built with. Otherwise, the "`msvcp140.dll`" you deployed in the same directory as
 your .exe would "win" over the versions in System32.
 
-## Complete example using x64 DLL flavor
+## Complete Example Using x64 DLL Flavor
 
 The compiler looks for include directories according to the `INCLUDE` environment variable, and the linker looks for
 import library directories according to the `LIB` environment variable, and the Windows loader will (eventually) look
@@ -237,7 +237,7 @@ When you submit a pull request, a CLA bot will automatically determine whether y
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
-# Code of Conduct
+# Code Of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct][]. For more information see the
 [Code of Conduct FAQ][] or contact [opencode@microsoft.com][] with any additional questions or comments.
@@ -270,4 +270,4 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [libcxx]: https://libcxx.llvm.org
 [opencode@microsoft.com]: mailto:opencode@microsoft.com
 [redistributables]: https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads
-[vcpkg]: https://github.com/Microsoft/vcpkg
+[vcpkg]: https://github.com/microsoft/vcpkg

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -1,0 +1,6 @@
+:: Copyright (c) Microsoft Corporation.
+:: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+@echo off
+clang-format -style=file -i stl/inc/* stl/inc/cvt/* stl/inc/experimental/* stl/src/* 2>&1
+echo If your build fails here, you need to format the following files with clang-format 8.0.1.
+git status --porcelain 1>&2

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -3,4 +3,4 @@
 @echo off
 clang-format -style=file -i stl/inc/* stl/inc/cvt/* stl/inc/experimental/* stl/src/* 2>&1
 echo If your build fails here, you need to format the following files with clang-format 8.0.1.
-git status --porcelain 1>&2
+git status --porcelain stl 1>&2

--- a/azure-devops/install_msvc_preview.ps1
+++ b/azure-devops/install_msvc_preview.ps1
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+$ErrorActionPreference = "Stop"
+
+Function InstallVS
+{
+    # Microsoft hosted agents do not have the required MSVC Preview for building MSVC STL.
+    # This step installs MSVC Preview, only on Microsoft hosted agents.
+
+  Param(
+    [String]$WorkLoads,
+    [String]$Sku,
+    [String]$VSBootstrapperURL)
+  $exitCode = -1
+  try
+  {
+    Write-Host "Downloading bootstrapper ..."
+    [string]$bootstrapperExe = Join-Path ${env:Temp} ([System.IO.Path]::GetRandomFileName() + ".exe")
+    Invoke-WebRequest -Uri $VSBootstrapperURL -OutFile $bootstrapperExe
+
+    $Arguments = ('/c', $bootstrapperExe, $WorkLoads, '--quiet', '--norestart', '--wait', '--nocache')
+
+    Write-Host "Starting Install: $Arguments"
+    $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru
+    $exitCode = $process.ExitCode
+
+    if ($exitCode -eq 0 -or $exitCode -eq 3010)
+    {
+      Write-Host -Object 'Installation successful!'
+    }
+    else
+    {
+      Write-Host -Object "Nonzero exit code returned by the installation process : $exitCode."
+    }
+  }
+  catch
+  {
+    Write-Host -Object "Failed to install Visual Studio!"
+    Write-Host -Object $_.Exception.Message
+    exit $exitCode
+  }
+
+  exit $exitCode
+}
+
+# Invalidate the standard installation of VS on the hosted agent.
+Move-Item "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/" "C:/Program Files (x86)/Microsoft Visual Studio/2019/nouse/" -Verbose
+
+$WorkLoads =  '--add Microsoft.VisualStudio.Component.VC.CLI.Support ' + `
+              '--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ' + `
+              '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ' + `
+              '--add Microsoft.VisualStudio.Component.VC.Tools.ARM ' + `
+              '--add Microsoft.VisualStudio.Component.Windows10SDK.18362 '
+
+$ReleaseInPath = 'Preview'
+$Sku = 'Enterprise'
+$VSBootstrapperURL = 'https://aka.ms/vs/16/pre/vs_buildtools.exe'
+
+$ErrorActionPreference = 'Stop'
+
+# Install VS
+$exitCode = InstallVS -WorkLoads $WorkLoads -Sku $Sku -VSBootstrapperURL $VSBootstrapperURL
+
+exit $exitCode

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+parameters:
+  targetPlatform: 'x64'
+
+jobs:
+- job: ${{ parameters.targetPlatform }}
+  pool:
+    name: STL
+
+  variables:
+    vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
+    vcpkgResponseFile: $(Build.SourcesDirectory)/vcpkg_windows.txt
+  steps:
+    - checkout: self
+      submodules: recursive
+    - task: BatchScript@1
+      displayName: 'Enforce clang-format'
+      condition: eq('${{ parameters.targetPlatform }}', 'x86')
+      inputs:
+        filename: 'azure-devops/enforce-clang-format.cmd'
+        failOnStandardError: true
+    - task: PowerShell@2
+      displayName: 'Install MSVC preview'
+      # on "Hosted" agents only:
+      condition: or(contains(variables['Agent.Name'], 'Azure Pipelines'), contains(variables['Agent.Name'], 'Hosted Agent'))
+      inputs:
+        targetType: filePath
+        filePath: $(Build.SourcesDirectory)/azure-devops/install_msvc_preview.ps1
+    - task: CacheBeta@0
+      displayName: Cache vcpkg
+      inputs:
+        key: $(vcpkgResponseFile) | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD
+        path: '$(vcpkgLocation)'
+    - task: run-vcpkg@0
+      displayName: 'Run vcpkg to install boost-build'
+      inputs:
+        vcpkgArguments: 'boost-build:x86-windows'
+        vcpkgDirectory: '$(vcpkgLocation)'
+    - task: run-vcpkg@0
+      displayName: 'Run vcpkg'
+      inputs:
+        vcpkgArguments: '@$(vcpkgResponseFile)'
+        vcpkgDirectory: '$(vcpkgLocation)'
+        vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
+    - task: run-cmake@0
+      displayName: 'Run CMake with Ninja'
+      enabled: true
+      inputs:
+        cmakeListsTxtPath: 'CMakeSettings.json'
+        useVcpkgToolchainFile: true
+        configurationRegexFilter: '.*${{ parameters.targetPlatform }}.*'
+        buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,21 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-pool: 'STL'
 
-steps:
-- task: BatchScript@1
-  inputs:
-    filename: 'azure-devops/enforce-clang-format.cmd'
-    failOnStandardError: true
-    displayName: 'Enforce clang-format'
+# Build STL targeting x86, x64, arm, arm64
+
+jobs:
+- template: azure-devops/run_build.yml
+  parameters:
+    targetPlatform: x86
+
+- template: azure-devops/run_build.yml
+  parameters:
+    targetPlatform: x64
+
+- template: azure-devops/run_build.yml
+  parameters:
+    targetPlatform: arm
+
+- template: azure-devops/run_build.yml
+  parameters:
+    targetPlatform: arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+pool: 'STL'
+
+steps:
+- task: BatchScript@1
+  inputs:
+    filename: 'azure-devops/enforce-clang-format.cmd'
+    failOnStandardError: true
+    displayName: 'Enforce clang-format'

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-* @StephanTLavavej @CaseyCarter @barcharcraz @BillyONeal
+* @microsoft/vclibs

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -23,8 +23,8 @@ C:\Users\billy\Desktop>type repro.cpp
 int main() {
     // Replace this program with one demonstrating your actual bug report,
     // along with the following compilation command. Please leave compiler
-    // version banners in the output (don't use /nologo), and include output of
-    // your test program, if any.
+    // version banners in the output (don't use /nologo), and include output
+    // of your test program, if any.
     std::cout << "test failure\n";
 }
 
@@ -44,8 +44,9 @@ test failure
 ```
 
 **Expected behavior**
-A clear and concise description of what you expected to happen. Alternately,
-include `static_assert`s or `assert`s in your test case above whose failure clearly indicates the problem.
+A clear and concise description of what you expected to happen. Alternatively,
+include `static_assert`s or `assert`s in your test case above whose failure
+clearly indicates the problem.
 
 **Additional context**
 Add any other context about the problem here.

--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -8,6 +8,15 @@
                     "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
                 }
             }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/microsoft/STL.git",
+                    "commitHash": "d5c2a9aaaac737216ac6bfa890a26f1a2cd8b4b1"
+                }
+            }
         }
     ],
     "Version": 1

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,23 +1,30 @@
-Please note that acceptance of community PRs will be delayed while we are
-bringing our test and CI systems online. For more information, see the
-README.md.
-
 # Description
 
-# Checklist:
 
-- [ ] I understand README.md.
-- [ ] If this is a feature addition, that feature has been voted into the C++
-  Working Draft.
-- [ ] Identifiers in any product code changes are properly `_Ugly` as per
+
+# Checklist
+
+If you're unsure about a box, leave it unchecked. A maintainer will help you.
+
+If a box isn't applicable, add an explanation in **bold**.
+For example: **(N/A: this is a bugfix, not a feature)**
+
+- [ ] I understand README.md. I also understand that acceptance of
+  community PRs will be delayed until the test and CI systems are online.
+- [ ] If this is a feature addition, that feature has been voted into the
+  C++ Working Draft.
+- [ ] Identifiers in product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 .
-- [ ] Identifiers in test code changes are *not* `_Ugly`.
-- [ ] Test code includes the correct headers as per the Standard, not just
-  what happens to compile.
-- [ ] The STL builds and test harnesses have passed (must be manually verified
-  by an STL maintainer before CI is online, leave this unchecked for initial
-  submission).
-- [ ] This change introduces no known ABI breaks (adding members, renaming
-  members, adding virtual functions, changing whether a type is an aggregate or
-  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
-  maintainer for help.
+- [ ] The STL builds successfully and all tests have passed (must be manually
+  verified by an STL maintainer before CI is online, leave this unchecked for
+  initial submission).
+- [ ] These changes introduce no known ABI breaks (adding members, renaming
+  members, adding virtual functions, changing whether a type is an aggregate
+  or trivially copyable, etc.).
+- [ ] These changes were written from scratch using only this repository and
+  the C++ Working Draft as a reference (and any other cited standards).
+  If they were derived from a project that's already listed in NOTICE.txt,
+  that's fine, but please mention it. If they were derived from any other
+  project (including Boost and libc++, which are not yet listed in
+  NOTICE.txt), you *must* mention it here, so we can determine whether the
+  license is compatible and what else needs to be done.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -9,8 +9,6 @@ README.md.
 - [ ] I understand README.md.
 - [ ] If this is a feature addition, that feature has been voted into the C++
   Working Draft.
-- [ ] Any code files edited have been processed by clang-format 8.0.1.
-  (The version is important because clang-format's behavior sometimes changes.)
 - [ ] Identifiers in any product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 .
 - [ ] Identifiers in test code changes are *not* `_Ugly`.

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -411,6 +411,39 @@ _NODISCARD bool operator>=(const array<_Ty, _Size>& _Left, const array<_Ty, _Siz
     return !(_Left < _Right);
 }
 
+#if _HAS_CXX20
+// FUNCTION TEMPLATE to_array
+template <class _Ty, size_t _Size, size_t... _Idx>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> _To_array_lvalue_impl(
+    _Ty (&_Array)[_Size], index_sequence<_Idx...>) {
+    return {{_Array[_Idx]...}};
+}
+
+template <class _Ty, size_t _Size, size_t... _Idx>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> _To_array_rvalue_impl(
+    _Ty(&&_Array)[_Size], index_sequence<_Idx...>) {
+    return {{_STD move(_Array[_Idx])...}};
+}
+
+template <class _Ty, size_t _Size>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty (&_Array)[_Size]) {
+    static_assert(!is_array_v<_Ty>, "N4830 [array.creation]/1: "
+                                    "to_array does not accept multidimensional arrays.");
+    static_assert(is_constructible_v<_Ty, _Ty&>, "N4830 [array.creation]/1: "
+                                                 "to_array requires copy constructible elements.");
+    return _To_array_lvalue_impl(_Array, make_index_sequence<_Size>{});
+}
+
+template <class _Ty, size_t _Size>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty(&&_Array)[_Size]) {
+    static_assert(!is_array_v<_Ty>, "N4830 [array.creation]/4: "
+                                    "to_array does not accept multidimensional arrays.");
+    static_assert(is_move_constructible_v<_Ty>, "N4830 [array.creation]/4: "
+                                                "to_array requires move constructible elements.");
+    return _To_array_rvalue_impl(_STD move(_Array), make_index_sequence<_Size>{});
+}
+#endif // _HAS_CXX20
+
 // TUPLE INTERFACE TO array
 template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr _Ty& get(array<_Ty, _Size>& _Arr) noexcept {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -161,7 +161,7 @@ _Ty kill_dependency(_Ty _Arg) noexcept { // "magic" template that kills dependen
 // FUNCTION _Check_memory_order
 inline void _Check_memory_order(const memory_order _Order) noexcept {
     // check that _Order is a valid memory_order
-    if (static_cast<unsigned int>(_Order) > memory_order_seq_cst) {
+    if (static_cast<unsigned int>(_Order) > static_cast<unsigned int>(memory_order_seq_cst)) {
         _INVALID_MEMORY_ORDER;
     }
 }
@@ -230,7 +230,7 @@ _NODISCARD inline memory_order _Combine_cas_memory_orders(
 
     _Check_memory_order(_Success);
     _Check_load_memory_order(_Failure);
-    return _Combined_memory_orders[_Success][_Failure];
+    return _Combined_memory_orders[static_cast<int>(_Success)][static_cast<int>(_Failure)];
 }
 
 // FUNCTION TEMPLATE _Atomic_reinterpret_as

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -26,9 +26,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-// TRANSITION, Several names herein are declared as _Xxx_xxx2; in all such cases the corresponding
-// _Xxx_xxx name is an ABI zombie name
-
 _EXTERN_C
 // If on Windows XP, returns 1 (disabling parallelism); otherwise, returns the number of hardware threads available.
 _NODISCARD unsigned int __stdcall __std_parallel_algorithms_hw_threads() noexcept;
@@ -2901,7 +2898,6 @@ struct _Bottom_up_tree_visitor {
     }
 };
 
-// TRANSITION, _Static_partitioned_stable_sort2 is an ABI zombie name
 template <class _BidIt, class _Pr>
 struct _Static_partitioned_stable_sort3 {
     using _Diff = _Iter_diff_t<_BidIt>;

--- a/stl/inc/experimental/resumable
+++ b/stl/inc/experimental/resumable
@@ -25,6 +25,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#if defined(__clang__) && !defined(_SILENCE_CLANG_COROUTINE_MESSAGE)
+#error The <experimental/coroutine>, <experimental/generator>, and <experimental/resumable> headers currently do not \
+support Clang. You can define _SILENCE_CLANG_COROUTINE_MESSAGE to silence this message and acknowledge that this is \
+unsupported.
+#endif // defined(__clang__) && !defined(_SILENCE_CLANG_COROUTINE_MESSAGE)
+
 // intrinsics used in implementation of coroutine_handle
 extern "C" size_t _coro_resume(void*);
 extern "C" void _coro_destroy(void*);

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -576,7 +576,6 @@ public:
 };
 
 // STRUCT TEMPLATE _List_node_emplace_op2
-// _List_node_emplace_op is an ABI zombie name
 template <class _Alnode>
 struct _List_node_emplace_op2 : _Alloc_construct_ptr<_Alnode> {
     using _Alnode_traits = allocator_traits<_Alnode>;

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1732,19 +1732,19 @@ private:
             }
 
             auto& _Right_data = _Right._Mypair._Myval2;
-            _My_data._Mysize += _Count;
-            _Right_data._Mysize -= _Count;
-
 #if _ITERATOR_DEBUG_LEVEL == 2
             // transfer ownership
             if (_Count == 1) {
                 _My_data._Adopt_unique(_Right_data, _First);
-            } else if (_Count == _Right.size()) {
+            } else if (_Count == _Right_data._Mysize) {
                 _My_data._Adopt_all(_Right_data);
             } else {
                 _My_data._Adopt_range(_Right_data, _First, _Last);
             }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
+
+            _My_data._Mysize += _Count;
+            _Right_data._Mysize -= _Count;
         }
 
         return _Scary_val::_Unchecked_splice(_Where, _First, _Last);

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -23,7 +23,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 // FUNCTION TEMPLATE uninitialized_copy_n
-// TRANSITION: _Uninitialized_copy_n_unchecked and _Uninitialized_copy_n_unchecked1 are ABI zombie names
 #if _HAS_IF_CONSTEXPR
 template <class _InIt, class _Diff, class _NoThrowFwdIt>
 _NoThrowFwdIt uninitialized_copy_n(const _InIt _First, const _Diff _Count_raw, _NoThrowFwdIt _Dest) {
@@ -142,7 +141,6 @@ _OutTy* uninitialized_move(const _InIt _First, const _InIt _Last, _OutTy (&_Dest
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 // FUNCTION TEMPLATE uninitialized_move_n
-// TRANSITION, _Uninitialized_move_n_unchecked is an ABI zombie name
 #if _HAS_IF_CONSTEXPR
 template <class _InIt, class _Diff, class _NoThrowFwdIt>
 pair<_InIt, _NoThrowFwdIt> uninitialized_move_n(_InIt _First, const _Diff _Count_raw, _NoThrowFwdIt _Dest) {
@@ -251,7 +249,6 @@ pair<_InTy*, _OutTy*> uninitialized_move_n(_InTy (&_First)[_InSize], const _Diff
 #endif // _HAS_CXX17
 
 // FUNCTION TEMPLATE uninitialized_fill_n
-// TRANSITION: _Uninitialized_fill_n_unchecked is an ABI zombie name
 #if _HAS_IF_CONSTEXPR
 template <class _NoThrowFwdIt, class _Diff, class _Tval>
 _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw, const _Tval& _Val) {
@@ -1480,8 +1477,6 @@ template <class _Dx, class _Ty>
 _Dx* get_deleter(const shared_ptr<_Ty>&) noexcept = delete; // requires static RTTI
 #endif // _HAS_STATIC_RTTI
 
-// _Ref_count_obj is an ABI zombie name
-
 // CLASS TEMPLATE _Ref_count_obj2
 template <class _Ty>
 class _Ref_count_obj2 : public _Ref_count_base { // handle reference counting for object in control block, no allocator
@@ -1548,8 +1543,6 @@ protected:
         return _Myval;
     }
 };
-
-// _Ref_count_obj_alloc is an ABI zombie name
 
 // CLASS TEMPLATE _Ref_count_obj_alloc2
 template <class _Ty, class _Alloc>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -134,7 +134,8 @@ namespace regex_constants {
         format_sed        = 0x0400,
         format_no_copy    = 0x0800,
         format_first_only = 0x1000,
-        _Match_not_null   = 0x2000
+        _Match_not_null   = 0x2000,
+        _Skip_zero_length = 0x4000,
     };
 
     _BITMASK_OPS(match_flag_type)
@@ -2213,17 +2214,21 @@ _NODISCARD bool regex_match(const basic_string<_Elem, _StTraits, _StAlloc>& _Str
         _Re, _Flgs | regex_constants::match_any, true);
 }
 
-// FUNCTION TEMPLATE _Regex_search1
+// FUNCTION TEMPLATE _Regex_search2
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
-bool _Regex_search1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
-    const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs,
-    _It _Org) { // search for regular expression match in target text
+bool _Regex_search2(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
+    const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs, _It _Org) {
+    // search for regular expression match in target text
     if (_Re._Empty()) {
         return false;
     }
 
-    bool _Found = false;
-    _It _Begin  = _First;
+    bool _Found      = false;
+    const _It _Begin = _First;
+    if ((_Flgs & regex_constants::_Skip_zero_length) && _First != _Last) {
+        ++_First;
+    }
+
     _Matcher<_BidIt, _Elem, _RxTraits, _It> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs);
 
@@ -2258,7 +2263,7 @@ bool regex_search(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _M
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     _Adl_verify_range(_First, _Last);
-    return _Regex_search1(_First, _Last, _STD addressof(_Matches), _Re, _Flgs, _First);
+    return _Regex_search2(_First, _Last, _STD addressof(_Matches), _Re, _Flgs, _First);
 }
 
 template <class _BidIt, class _Elem, class _RxTraits>
@@ -2266,7 +2271,7 @@ _NODISCARD bool regex_search(_BidIt _First, _BidIt _Last, const basic_regex<_Ele
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     _Adl_verify_range(_First, _Last);
-    return _Regex_search1(_Get_unwrapped(_First), _Get_unwrapped(_Last),
+    return _Regex_search2(_Get_unwrapped(_First), _Get_unwrapped(_Last),
         static_cast<match_results<_Unwrapped_t<_BidIt>>*>(nullptr), _Re, _Flgs | regex_constants::match_any,
         _Get_unwrapped(_First));
 }
@@ -2276,7 +2281,7 @@ _NODISCARD bool regex_search(_In_z_ const _Elem* _Str, const basic_regex<_Elem, 
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     const _Elem* _Last = _Str + char_traits<_Elem>::length(_Str);
-    return _Regex_search1(
+    return _Regex_search2(
         _Str, _Last, static_cast<match_results<const _Elem*>*>(nullptr), _Re, _Flgs | regex_constants::match_any, _Str);
 }
 
@@ -2285,7 +2290,7 @@ bool regex_search(_In_z_ const _Elem* _Str, match_results<const _Elem*, _Alloc>&
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     const _Elem* _Last = _Str + char_traits<_Elem>::length(_Str);
-    return _Regex_search1(_Str, _Last, _STD addressof(_Matches), _Re, _Flgs, _Str);
+    return _Regex_search2(_Str, _Last, _STD addressof(_Matches), _Re, _Flgs, _Str);
 }
 
 template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2293,7 +2298,7 @@ bool regex_search(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     match_results<typename basic_string<_Elem, _StTraits, _StAlloc>::const_iterator, _Alloc>& _Matches,
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
-    return _Regex_search1(_Str.begin(), _Str.end(), _STD addressof(_Matches), _Re, _Flgs, _Str.begin());
+    return _Regex_search2(_Str.begin(), _Str.end(), _STD addressof(_Matches), _Re, _Flgs, _Str.begin());
 }
 
 template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2309,7 +2314,7 @@ _NODISCARD bool regex_search(const basic_string<_Elem, _StTraits, _StAlloc>& _St
 
     _Iter _First = _Str.c_str();
     _Iter _Last  = _First + _Str.size();
-    return _Regex_search1(
+    return _Regex_search2(
         _First, _Last, static_cast<match_results<_Iter>*>(nullptr), _Re, _Flgs | regex_constants::match_any, _First);
 }
 
@@ -2324,7 +2329,7 @@ _OutIt _Regex_replace1(_OutIt _Result, _BidIt _First, _BidIt _Last, const basic_
     regex_constants::match_flag_type _Not_null{};
 
     while (
-        _Regex_search1(_Pos, _Last, _STD addressof(_Matches), _Re, _Flags | _Not_null, _Pos)) { // replace at each match
+        _Regex_search2(_Pos, _Last, _STD addressof(_Matches), _Re, _Flags | _Not_null, _Pos)) { // replace at each match
         if (!(_Flgs & regex_constants::format_no_copy)) {
             _Result = _STD copy(_Matches.prefix().first, _Matches.prefix().second, _Result);
         }
@@ -2446,7 +2451,7 @@ public:
         regex_constants::match_flag_type _Fl = regex_constants::match_default)
         : _Begin(_First), _End(_Last), _MyRe(_STD addressof(_Re)), _Flags(_Fl) {
         _Adl_verify_range(_Begin, _End);
-        if (!_Regex_search1(_Begin, _End, _STD addressof(_MyVal), *_MyRe, _Flags, _Begin)) {
+        if (!_Regex_search2(_Begin, _End, _STD addressof(_MyVal), *_MyRe, _Flags, _Begin)) {
             _MyRe = nullptr;
         } else {
             this->_Adopt(_MyRe);
@@ -2498,6 +2503,7 @@ public:
         _STL_VERIFY(this->_Getcont(), "regex_iterator orphaned");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
+        bool _Skip_empty_match = false;
         if (_MyVal._At(0).first == _MyVal._At(0).second) { // handle zero-length match
             if (_Start == _End) { // store end-of-sequence iterator
                 _MyRe = nullptr;
@@ -2510,17 +2516,23 @@ public:
             }
 
             // _Adl_verify_range(_Start, _End) checked in constructor
-            if (_Regex_search1(_Start, _End, _STD addressof(_MyVal), *_MyRe,
+            if (_Regex_search2(_Start, _End, _STD addressof(_MyVal), *_MyRe,
                     _Flags | regex_constants::match_not_null | regex_constants::match_continuous, _Begin)) {
                 return *this;
             }
 
-            ++_Start;
+            _Skip_empty_match = true;
         }
         _Flags = _Flags | regex_constants::match_prev_avail;
 
+        auto _Tmp_flags = _Flags;
+        if (_Skip_empty_match) {
+            _Tmp_flags |= regex_constants::_Skip_zero_length;
+        }
+
         // _Adl_verify_range(_Start, _End) checked in constructor
-        if (!_Regex_search1(_Start, _End, _STD addressof(_MyVal), *_MyRe, _Flags, _Begin)) { // mark at end of sequence
+        if (!_Regex_search2(_Start, _End, _STD addressof(_MyVal), *_MyRe, _Tmp_flags, _Begin)) {
+            // mark at end of sequence
             _MyRe = nullptr;
         }
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -331,6 +331,28 @@ _INLINE_VAR constexpr bool is_array_v<_Ty[]> = true;
 template <class _Ty>
 struct is_array : bool_constant<is_array_v<_Ty>> {};
 
+#if _HAS_CXX20
+// STRUCT TEMPLATE is_bounded_array
+template <class>
+inline constexpr bool is_bounded_array_v = false;
+
+template <class _Ty, size_t _Nx>
+inline constexpr bool is_bounded_array_v<_Ty[_Nx]> = true;
+
+template <class _Ty>
+struct is_bounded_array : bool_constant<is_bounded_array_v<_Ty>> {};
+
+// STRUCT TEMPLATE is_unbounded_array
+template <class>
+inline constexpr bool is_unbounded_array_v = false;
+
+template <class _Ty>
+inline constexpr bool is_unbounded_array_v<_Ty[]> = true;
+
+template <class _Ty>
+struct is_unbounded_array : bool_constant<is_unbounded_array_v<_Ty>> {};
+#endif // _HAS_CXX20
+
 // STRUCT TEMPLATE is_lvalue_reference
 template <class>
 _INLINE_VAR constexpr bool is_lvalue_reference_v = false; // determine whether type argument is an lvalue reference

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -552,7 +552,6 @@ public:
     }
 
 private:
-    // _Move_from is an ABI zombie name
     void _Move_construct(vector& _Right, true_type) noexcept { // move from _Right, stealing its contents
         _Mypair._Myval2._Take_contents(_Right._Mypair._Myval2);
     }
@@ -1574,8 +1573,6 @@ public:
     }
 
 private:
-    // _Udefault is an ABI zombie name
-
     pointer _Ufill(pointer _Dest, const size_type _Count, const _Ty& _Val) {
         // fill raw _Dest with _Count copies of _Val, using allocator
         return _Uninitialized_fill_n(_Dest, _Count, _Val, _Getal());
@@ -1632,7 +1629,6 @@ private:
         return _Geometric; // geometric growth is sufficient
     }
 
-    // _Buy is an ABI zombie name
     void _Buy_raw(const size_type _Newcapacity) {
         // allocate array with _Newcapacity elements
         auto& _My_data    = _Mypair._Myval2;

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -57,7 +57,22 @@ _STD_BEGIN
 
 #if _HAS_CXX20
 // ENUM CLASS memory_order
-enum class memory_order : int { relaxed, consume, acquire, release, acq_rel, seq_cst };
+enum class memory_order : int {
+    relaxed,
+    consume,
+    acquire,
+    release,
+    acq_rel,
+    seq_cst,
+
+    // LWG 3268
+    memory_order_relaxed = relaxed,
+    memory_order_consume = consume,
+    memory_order_acquire = acquire,
+    memory_order_release = release,
+    memory_order_acq_rel = acq_rel,
+    memory_order_seq_cst = seq_cst
+};
 inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
 inline constexpr memory_order memory_order_consume = memory_order::consume;
 inline constexpr memory_order memory_order_acquire = memory_order::acquire;

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -55,6 +55,16 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
+#if _HAS_CXX20
+// ENUM CLASS memory_order
+enum class memory_order : int { relaxed, consume, acquire, release, acq_rel, seq_cst };
+inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
+inline constexpr memory_order memory_order_consume = memory_order::consume;
+inline constexpr memory_order memory_order_acquire = memory_order::acquire;
+inline constexpr memory_order memory_order_release = memory_order::release;
+inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
+inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
+#else // _HAS_CXX20
 // ENUM memory_order
 enum memory_order {
     memory_order_relaxed,
@@ -64,6 +74,7 @@ enum memory_order {
     memory_order_acq_rel,
     memory_order_seq_cst
 };
+#endif // _HAS_CXX20
 
 using _Atomic_counter_t = unsigned long;
 

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -999,7 +999,6 @@ public:
         return _Vec.max_size() >> 1;
     }
 
-    // _Hashval is an ABI zombie name
     _NODISCARD size_type bucket(const key_type& _Keyval) const
         noexcept(_Nothrow_hash<_Traits, key_type>) /* strengthened */ {
         return _Traitsobj(_Keyval) & _Mask;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3397,7 +3397,6 @@ _DestTy* copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _DestTy (&_Dest)[_DestSize
 #endif // _HAS_CXX17
 
 // FUNCTION TEMPLATE copy_n
-// TRANSITION: _Copy_n_unchecked, _Copy_n_unchecked1, _Copy_n_unchecked2, and _Copy_n_unchecked3 are ABI zombie names
 #if _HAS_IF_CONSTEXPR
 template <class _InIt, class _Diff, class _OutIt>
 _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) { // copy [_First, _First + _Count) to [_Dest, ...)
@@ -3849,7 +3848,6 @@ void fill(_ExPo&&, _FwdIt _First, _FwdIt _Last, const _Ty& _Val) noexcept /* ter
 #endif // _HAS_CXX17
 
 // FUNCTION TEMPLATE fill_n
-// TRANSITION: _Fill_n_unchecked and _Fill_n_unchecked1 are ABI zombie names
 #if _HAS_IF_CONSTEXPR
 template <class _OutIt, class _Diff, class _Ty>
 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1994,7 +1994,6 @@ _NODISCARD _CONSTEXPR17 auto crend(const _Container& _Cont) -> decltype(_STD ren
     return _STD rend(_Cont);
 }
 
-
 template <class _Container>
 _NODISCARD constexpr auto size(const _Container& _Cont) -> decltype(_Cont.size()) {
     return _Cont.size();
@@ -2004,6 +2003,21 @@ template <class _Ty, size_t _Size>
 _NODISCARD constexpr size_t size(const _Ty (&)[_Size]) noexcept {
     return _Size;
 }
+
+#if _HAS_CXX20
+// FUNCTION TEMPLATE ssize
+template <class _Container>
+_NODISCARD constexpr auto ssize(const _Container& _Cont)
+    -> common_type_t<ptrdiff_t, make_signed_t<decltype(_Cont.size())>> {
+    using _Common = common_type_t<ptrdiff_t, make_signed_t<decltype(_Cont.size())>>;
+    return static_cast<_Common>(_Cont.size());
+}
+
+template <class _Ty, ptrdiff_t _Size>
+_NODISCARD constexpr ptrdiff_t ssize(const _Ty (&)[_Size]) noexcept {
+    return _Size;
+}
+#endif // _HAS_CXX20
 
 template <class _Container>
 _NODISCARD constexpr auto empty(const _Container& _Cont) -> decltype(_Cont.empty()) {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -21,6 +21,7 @@
 // _HAS_CXX20 directly controls:
 // P0020R6 atomic<float>, atomic<double>, atomic<long double>
 // P0318R1 unwrap_reference, unwrap_ref_decay
+// P0325R4 to_array()
 // P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
 // P0458R2 contains() For Ordered And Unordered Associative Containers
 // P0463R1 endian
@@ -912,6 +913,7 @@
 
 #define __cpp_lib_generic_unordered_lookup 201811L
 #define __cpp_lib_list_remove_return_type 201806L
+#define __cpp_lib_to_array 201907L
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -22,6 +22,7 @@
 // P0020R6 atomic<float>, atomic<double>, atomic<long double>
 // P0318R1 unwrap_reference, unwrap_ref_decay
 // P0325R4 to_array()
+// P0439R0 enum class memory_order
 // P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
 // P0458R2 contains() For Ordered And Unordered Associative Containers
 // P0463R1 endian

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -44,6 +44,7 @@
 //     (partially implemented)
 // P0898R3 Standard Library Concepts
 // P0919R3 Heterogeneous Lookup For Unordered Containers
+// P1357R1 is_bounded_array, is_unbounded_array
 // P1754R1 Rename Concepts To standard_case
 // P????R? directory_entry::clear_cache()
 
@@ -890,6 +891,7 @@
 
 // C++20
 #if _HAS_CXX20
+#define __cpp_lib_bounded_array_traits 201902L
 #ifdef __cpp_char8_t
 #define __cpp_lib_char8_t 201811L
 #endif // __cpp_char8_t

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -44,6 +44,8 @@
 //     (partially implemented)
 // P0898R3 Standard Library Concepts
 // P0919R3 Heterogeneous Lookup For Unordered Containers
+// P1227R2 Signed std::ssize(), Unsigned span::size()
+//     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
 // P1754R1 Rename Concepts To standard_case
 // P????R? directory_entry::clear_cache()

--- a/vcpkg_windows.txt
+++ b/vcpkg_windows.txt
@@ -1,0 +1,5 @@
+boost-build:x86-windows
+boost-math:x86-windows
+boost-math:x64-windows
+boost-math:arm-windows
+boost-math:arm64-windows


### PR DESCRIPTION
Please note that acceptance of community PRs will be delayed while we are
bringing our test and CI systems online. For more information, see the
README.md.

# Description

# Checklist:

- [ ] I understand README.md.
- [ ] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [ ] Any code files edited have been processed by clang-format 8.0.1.
  (The version is important because clang-format's behavior sometimes changes.)
- [ ] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] Identifiers in test code changes are *not* `_Ugly`.
- [ ] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [ ] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [ ] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
