### PR TITLE
Update README and PR template (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ issue. The [bug tag][] and [enhancement tag][] remain to be populated.
 
 # Goals
 
-We're implementing the latest C++ Working Draft, currently [N4830][], which will eventually become the next C++
+We're implementing the latest C++ Working Draft, currently [N4835][], which will eventually become the next C++
 International Standard (which is sometimes referred to as C++2a, but we optimistically refer to it as C++20). The terms
 Working Draft (WD) and Working Paper (WP) are interchangeable; we often informally refer to these drafts as "the
 Standard" while being aware of the difference. (There are other relevant Standards; for example, supporting `/std:c++14`
@@ -257,7 +257,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [LWG issues]: https://cplusplus.github.io/LWG/lwg-toc.html
 [LWG tag]: https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3ALWG
 [Microsoft Open Source Code of Conduct]: https://opensource.microsoft.com/codeofconduct/
-[N4830]: https://wg21.link/n4830
+[N4835]: https://wg21.link/n4835
 [NOTICE.txt]: NOTICE.txt
 [Ninja]: https://ninja-build.org
 [Pipelines]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=2&branchName=master

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -6,15 +6,10 @@
 
 If you're unsure about a box, leave it unchecked. A maintainer will help you.
 
-If a box isn't applicable, add an explanation in **bold**.
-For example: **(N/A: this is a bugfix, not a feature)**
-
 - [ ] I understand README.md. I also understand that acceptance of
   community PRs will be delayed until the test and CI systems are online.
-- [ ] If this is a feature addition, that feature has been voted into the
-  C++ Working Draft.
 - [ ] Identifiers in product code changes are properly `_Ugly` as per
-  https://eel.is/c++draft/lex.name#3.1 .
+  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
 - [ ] The STL builds successfully and all tests have passed (must be manually
   verified by an STL maintainer before CI is online, leave this unchecked for
   initial submission).


### PR DESCRIPTION
* README.md: New Working Draft N4835.

* Simplify pull_request_template.md.

We can remove the N/A guidance by updating
the two checkboxes that are commonly N/A.

Remove the "feature has been voted into the WP" checkbox.
We haven't had issues with people submitting non-Standard PRs,
and the README's Non-Goals section clearly explains
our acceptance criteria.

For the `_Ugly` checkbox, allow people to check it
if there aren't any product code changes at all.

# Description



# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [ ] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
