### PR TITLE
LWG-3158 tuple(allocator_arg_t, const Alloc&) should be conditionally…

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1479,6 +1479,95 @@ namespace placeholders {
     _INLINE_VAR constexpr _Ph<20> _20{};
 } // namespace placeholders
 
+#if _HAS_CXX20
+// FUNCTION TEMPLATE _Call_front_binder
+template <size_t... _Ix, class _Cv_FD, class _Cv_tuple_TiD, class... _Unbound>
+constexpr auto _Call_front_binder(
+    index_sequence<_Ix...>, _Cv_FD&& _Obj, _Cv_tuple_TiD&& _Tpl, _Unbound&&... _Unbargs) //
+    noexcept(noexcept( //
+        _STD invoke(_STD forward<_Cv_FD>(_Obj), _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...,
+            _STD forward<_Unbound>(_Unbargs)...))) //
+    -> decltype( //
+        _STD invoke(_STD forward<_Cv_FD>(_Obj), _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...,
+            _STD forward<_Unbound>(_Unbargs)...)) { //
+    return _STD invoke(_STD forward<_Cv_FD>(_Obj), _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...,
+        _STD forward<_Unbound>(_Unbargs)...);
+}
+
+// CLASS TEMPLATE _Front_binder
+template <class _Fx, class... _Types>
+class _Front_binder { // wrap bound callable object and arguments
+private:
+    static_assert(is_constructible_v<decay_t<_Fx>, _Fx>,
+        "std::bind_front() requires the decayed callable to be constructible from an undecayed callable");
+    static_assert(is_move_constructible_v<decay_t<_Fx>>,
+        "std::bind_front() requires the decayed callable to be move constructible");
+    static_assert(conjunction_v<is_constructible<decay_t<_Types>, _Types>...>,
+        "std::bind_front() requires the decayed bound arguments to be constructible from undecayed bound arguments");
+    static_assert(conjunction_v<is_move_constructible<decay_t<_Types>>...>,
+        "std::bind_front() requires the decayed bound arguments to be move constructible");
+
+    using _Seq    = index_sequence_for<_Types...>;
+    using _First  = decay_t<_Fx>;
+    using _Second = tuple<decay_t<_Types>...>;
+
+    _Compressed_pair<_First, _Second> _Mypair;
+
+public:
+    constexpr explicit _Front_binder(_Fx&& _Func, _Types&&... _Args)
+        : _Mypair(_One_then_variadic_args_t{}, _STD forward<_Fx>(_Func), _STD forward<_Types>(_Args)...) {}
+
+    template <class... _Unbound>
+        constexpr auto operator()(_Unbound&&... _Unbargs) //
+        & noexcept(noexcept( //
+            _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) //
+          -> decltype( //
+              _Call_front_binder(
+                  _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)) { //
+        return _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    constexpr auto operator()(_Unbound&&... _Unbargs) //
+        const& noexcept(noexcept( //
+            _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) //
+        -> decltype( //
+            _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)) { //
+        return _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+        constexpr auto operator()(_Unbound&&... _Unbargs) //
+        && noexcept(noexcept( //
+            _Call_front_binder(_Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2),
+                _STD forward<_Unbound>(_Unbargs)...))) //
+           -> decltype( //
+               _Call_front_binder(_Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2),
+                   _STD forward<_Unbound>(_Unbargs)...)) { //
+        return _Call_front_binder(
+            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    constexpr auto operator()(_Unbound&&... _Unbargs) //
+        const&& noexcept(noexcept( //
+            _Call_front_binder(_Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2),
+                _STD forward<_Unbound>(_Unbargs)...))) //
+        -> decltype( //
+            _Call_front_binder(_Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2),
+                _STD forward<_Unbound>(_Unbargs)...)) { //
+        return _Call_front_binder(
+            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
+    }
+};
+
+// FUNCTION TEMPLATE bind_front
+template <class _Fx, class... _Types>
+_NODISCARD constexpr auto bind_front(_Fx&& _Func, _Types&&... _Args) {
+    return _Front_binder<_Fx, _Types...>(_STD forward<_Fx>(_Func), _STD forward<_Types>(_Args)...);
+}
+#endif // _HAS_CXX20
+
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
 // STRUCT TEMPLATE uses_allocator
 template <class _Fty, class _Alloc>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -419,9 +419,27 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
+#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _This2 = _This,
         enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...>, int> = 0>
+    explicit(
+        !conjunction_v<_Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>)
+        tuple(allocator_arg_t, const _Alloc& _Al)
+        : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
+#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
+    template <class _Alloc, class _This2 = _This,
+        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
+                        _Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>,
+            int> = 0>
     tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
+
+    template <class _Alloc, class _This2 = _This,
+        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
+                        negation<conjunction<_Is_implicitly_default_constructible<_This2>,
+                            _Is_implicitly_default_constructible<_Rest>...>>>,
+            int> = 0>
+    explicit tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
+#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _This2 = _This,

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -528,10 +528,10 @@ struct is_volatile : bool_constant<is_volatile_v<_Ty>> {};
 
 // STRUCT TEMPLATE is_pod
 template <class _Ty>
-struct is_pod : bool_constant<__is_pod(_Ty)> {}; // determine whether _Ty is a POD type
+struct _CXX20_DEPRECATE_IS_POD is_pod : bool_constant<__is_pod(_Ty)> {}; // determine whether _Ty is a POD type
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_pod_v = __is_pod(_Ty);
+_CXX20_DEPRECATE_IS_POD _INLINE_VAR constexpr bool is_pod_v = __is_pod(_Ty);
 
 // STRUCT TEMPLATE is_empty
 template <class _Ty>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1328,15 +1328,15 @@ public:
         : _Ty1(), _Myval2(_STD forward<_Other2>(_Val2)...) {}
 
     template <class _Other1, class... _Other2>
-    _Compressed_pair(_One_then_variadic_args_t, _Other1&& _Val1, _Other2&&... _Val2) noexcept(
+    constexpr _Compressed_pair(_One_then_variadic_args_t, _Other1&& _Val1, _Other2&&... _Val2) noexcept(
         conjunction_v<is_nothrow_constructible<_Ty1, _Other1>, is_nothrow_constructible<_Ty2, _Other2...>>)
         : _Ty1(_STD forward<_Other1>(_Val1)), _Myval2(_STD forward<_Other2>(_Val2)...) {}
 
-    _Ty1& _Get_first() noexcept {
+    constexpr _Ty1& _Get_first() noexcept {
         return *this;
     }
 
-    const _Ty1& _Get_first() const noexcept {
+    constexpr const _Ty1& _Get_first() const noexcept {
         return *this;
     }
 };
@@ -1353,15 +1353,15 @@ public:
         : _Myval1(), _Myval2(_STD forward<_Other2>(_Val2)...) {}
 
     template <class _Other1, class... _Other2>
-    _Compressed_pair(_One_then_variadic_args_t, _Other1&& _Val1, _Other2&&... _Val2) noexcept(
+    constexpr _Compressed_pair(_One_then_variadic_args_t, _Other1&& _Val1, _Other2&&... _Val2) noexcept(
         conjunction_v<is_nothrow_constructible<_Ty1, _Other1>, is_nothrow_constructible<_Ty2, _Other2...>>)
         : _Myval1(_STD forward<_Other1>(_Val1)), _Myval2(_STD forward<_Other2>(_Val2)...) {}
 
-    _Ty1& _Get_first() noexcept {
+    constexpr _Ty1& _Get_first() noexcept {
         return _Myval1;
     }
 
-    const _Ty1& _Get_first() const noexcept {
+    constexpr const _Ty1& _Get_first() const noexcept {
         return _Myval1;
     }
 };

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -22,6 +22,7 @@
 // P0020R6 atomic<float>, atomic<double>, atomic<long double>
 // P0318R1 unwrap_reference, unwrap_ref_decay
 // P0325R4 to_array()
+// P0356R5 bind_front()
 // P0439R0 enum class memory_order
 // P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
 // P0458R2 contains() For Ordered And Unordered Associative Containers
@@ -48,6 +49,7 @@
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 //     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
+// P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1754R1 Rename Concepts To standard_case
 // P????R? directory_entry::clear_cache()
 
@@ -908,6 +910,7 @@
 
 // C++20
 #if _HAS_CXX20
+#define __cpp_lib_bind_front 201907L
 #define __cpp_lib_bounded_array_traits 201902L
 #ifdef __cpp_char8_t
 #define __cpp_lib_char8_t 201811L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -123,6 +123,7 @@
 // Other C++17 deprecation warnings
 
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
+// P0767R1 Deprecating is_pod
 // Other C++20 deprecation warnings
 
 // Implemented unconditionally:
@@ -816,7 +817,20 @@
 #define _CXX20_DEPRECATE_STRING_RESERVE_WITHOUT_ARGUMENT
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4025
+// P0767R1 [depr.meta.types]
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_IS_POD_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+#define _CXX20_DEPRECATE_IS_POD                                                                                     \
+    [[deprecated("warning STL4025: "                                                                                \
+                 "std::is_pod and std::is_pod_v are deprecated in C++20. "                                          \
+                 "The std::is_trivially_copyable and/or std::is_standard_layout traits likely suit your use case. " \
+                 "You can define _SILENCE_CXX20_IS_POD_DEPRECATION_WARNING "                                        \
+                 "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _CXX20_DEPRECATE_IS_POD
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4026
 
 
 // LIBRARY FEATURE-TEST MACROS


### PR DESCRIPTION
# Description



# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
