### PR TITLE
Update required compiler versions (#231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.3 or later.
+1. Install Visual Studio 2019 16.4 preview 2 or later.
 2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`
@@ -148,7 +148,7 @@ acquire this dependency.
    and ARM64.
 6. Run `.\vcpkg.exe integrate install` which tells Visual Studio which vcpkg instance you wish to use. If you have never
    done this before, you may be prompted to elevate.
-7. Open Visual Studio 2019 16.3 or later, and choose the "Clone or check out code" option. Enter the URL to this
+7. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL to this
    repository, typically `https://github.com/microsoft/STL`
 8. Choose the architecture you wish to build in the IDE, and build as you would any other project. All necessary CMake
    settings are set by `CMakeSettings.json` and `vcpkg integrate`
@@ -158,7 +158,7 @@ acquire this dependency.
 These instructions assume you're targeting `x64-windows`; you can change this constant below to target other
 architectures.
 
-1. Install [CMake][] 3.15 or later, [Ninja][] 1.8.2 or later, and Visual Studio 2019 16.3 or later.
+1. Install [CMake][] 3.15 or later, [Ninja][] 1.8.2 or later, and Visual Studio 2019 16.4 preview 2 or later.
 2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -53,25 +53,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #error Unsupported hardware
 #endif // hardware
 
-#ifndef _STL_ATOMIC_LOAD_WITH_CMPXCHG8B
-#if !defined(_M_IX86)
-// On non-x86, we always have 64-bit load instructions.
-#define _STL_ATOMIC_LOAD_WITH_CMPXCHG8B 0
-#elif defined(__EDG__)
-// EDG treats the intrinsic as any other extern function.
-#define _STL_ATOMIC_LOAD_WITH_CMPXCHG8B 0
-#elif defined(__clang__)
-// TRANSITION, Clang 8.0.1 hasn't yet been taught about __iso_volatile_load64 on x86.
-#define _STL_ATOMIC_LOAD_WITH_CMPXCHG8B 1
-#elif defined(_MSC_VER) && _MSC_VER >= 1924
-// MSVC 19.24 is the first release with __iso_volatile_load64 for x86.
-#define _STL_ATOMIC_LOAD_WITH_CMPXCHG8B 0
-#else
-// Older than MSVC 19.24, use the older cmpxchg8b load operation.
-#define _STL_ATOMIC_LOAD_WITH_CMPXCHG8B 1
-#endif
-#endif // _STL_ATOMIC_LOAD_WITH_CMPXCHG8B
-
 #ifndef _INVALID_MEMORY_ORDER
 #ifdef _DEBUG
 #define _INVALID_MEMORY_ORDER _STL_REPORT_ERROR("Invalid memory order")
@@ -701,23 +682,6 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
     }
 #endif // _M_IX86
 
-#if _STL_ATOMIC_LOAD_WITH_CMPXCHG8B
-    _NODISCARD _Ty load(const memory_order _Order = memory_order_seq_cst) const noexcept {
-        // load with (effectively) sequential consistency
-        _Check_load_memory_order(_Order);
-        const auto _Mem_const = _Atomic_address_as<const long long>(_Storage);
-        const auto _Mem       = const_cast<volatile long long*>(_Mem_const); // OK because the CAS will always fail
-        long long _As_bytes;
-        _Compiler_barrier();
-        do {
-            _As_bytes = *_Mem;
-        } while (_As_bytes != _InterlockedCompareExchange64(_Mem, _As_bytes, _As_bytes));
-        _Compiler_barrier();
-
-        return reinterpret_cast<_Ty&>(_As_bytes);
-    }
-#else // ^^^ _STL_ATOMIC_LOAD_WITH_CMPXCHG8B / !_STL_ATOMIC_LOAD_WITH_CMPXCHG8B vvv
-
     _NODISCARD _Ty load() const noexcept { // load with sequential consistency
         const auto _Mem = _Atomic_address_as<const long long>(_Storage);
         long long _As_bytes;
@@ -735,7 +699,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
     }
 
     _NODISCARD _Ty load(const memory_order _Order) const noexcept { // load with given memory order
-        const auto _Mem     = _Atomic_address_as<const long long>(_Storage);
+        const auto _Mem = _Atomic_address_as<const long long>(_Storage);
 #if defined(_M_ARM)
         long long _As_bytes = __ldrexd(_Mem);
 #elif defined(_M_IX86) || defined(_M_ARM64)
@@ -746,7 +710,6 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
         _Load_barrier(_Order);
         return reinterpret_cast<_Ty&>(_As_bytes);
     }
-#endif // _STL_ATOMIC_LOAD_WITH_CMPXCHG8B
 
 #ifdef _M_IX86
     _Ty exchange(const _Ty _Value, const memory_order _Order = memory_order_seq_cst) noexcept {

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1187,17 +1187,6 @@ template <class _Ty, unsigned int _Ix = 0>
 struct extent : integral_constant<size_t, extent_v<_Ty, _Ix>> {};
 
 // STRUCT TEMPLATE is_base_of
-#ifdef __clang__ // TRANSITION, Clang 9
-template <class _Base, class _Derived, bool = __is_class(_Base) && __is_class(_Derived)>
-_INLINE_VAR constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
-
-template <class _Base, class _Derived>
-_INLINE_VAR constexpr bool is_base_of_v<_Base, _Derived, false> = false;
-
-template <class _Base, class _Derived>
-struct is_base_of : bool_constant<is_base_of_v<_Base, _Derived>> {};
-
-#else // ^^^ workaround / no workaround vvv
 template <class _Base, class _Derived>
 struct is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
     // determine whether _Base is a base of or the same as _Derived
@@ -1205,7 +1194,6 @@ struct is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
 
 template <class _Base, class _Derived>
 _INLINE_VAR constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
-#endif // TRANSITION, Clang 9
 
 // STRUCT TEMPLATE decay
 template <class _Ty>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -290,15 +290,15 @@
 
 // Controls whether the STL uses "conditional explicit" internally
 #ifndef _HAS_CONDITIONAL_EXPLICIT
-#if defined(__CUDACC__)
+#ifdef __cpp_conditional_explicit
+#define _HAS_CONDITIONAL_EXPLICIT 1
+#elif defined(__CUDACC__)
 #define _HAS_CONDITIONAL_EXPLICIT 0 // TRANSITION
-#elif defined(__EDG__)
-#define _HAS_CONDITIONAL_EXPLICIT 1
 #elif defined(__clang__)
-#define _HAS_CONDITIONAL_EXPLICIT 0 // TRANSITION, Clang 9
-#else // vvv C1XX vvv
+#define _HAS_CONDITIONAL_EXPLICIT 0 // TRANSITION, LLVM-42694
+#else // vvv C1XX or non-CUDA EDG vvv
 #define _HAS_CONDITIONAL_EXPLICIT 1
-#endif // ^^^ C1XX ^^^
+#endif // ^^^ C1XX or non-CUDA EDG ^^^
 #endif // _HAS_CONDITIONAL_EXPLICIT
 
 // warning C4577: 'noexcept' used with no exception handling mode specified;
@@ -423,12 +423,12 @@
 #ifdef __EDG__
 // not attempting to detect __EDG_VERSION__ being less than expected
 #elif defined(__clang__)
-#if __clang_major__ < 8 || (__clang_major__ == 8 && __clang_minor__ == 0 && __clang_patchlevel__ == 0)
-#error STL1000: Unexpected compiler version, expected Clang 8.0.1 or newer.
+#if __clang_major__ < 9
+#error STL1000: Unexpected compiler version, expected Clang 9.0.0 or newer.
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1923 // Coarse-grained, not inspecting _MSC_FULL_VER
-#error STL1001: Unexpected compiler version, expected MSVC 19.23 or newer.
+#if _MSC_VER < 1924 // Coarse-grained, not inspecting _MSC_FULL_VER
+#error STL1001: Unexpected compiler version, expected MSVC 19.24 or newer.
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers
@@ -540,7 +540,11 @@
 #define _CONSTEXPR_IF
 #endif // _HAS_IF_CONSTEXPR
 
-#define _CONSTEVAL constexpr // TRANSITION, Clang 9
+#ifdef __clang__
+#define _CONSTEVAL consteval
+#else // ^^^ supports consteval / no consteval vvv
+#define _CONSTEVAL constexpr
+#endif // ^^^ no consteval ^^^
 
 // Controls whether the STL will force /fp:fast to enable vectorization of algorithms defined
 // in the standard as special cases; such as reduce, transform_reduce, inclusive_scan, exclusive_scan


### PR DESCRIPTION
* Update required compiler versions

Update required version of MSVC to VS 2019 16.4p2, and Clang/LLVM to 9.0.0.

* Tell `<yvals_core.h>` that Clang 9 implements `consteval` (WG21 hasn't yet defined a feature-test macro for `consteval`)
* Tell `<atomic>` that Clang 9 implements the `__iso_volatile_load64` intrinsic on x86

* Update mentions of VS version in `README.md`

# Description



# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
