### PR TITLE
Remove delay comment in PR template because we've been merging PRs (m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yet hardened it against untrusted changes.
 conventions, Standard requirements, Microsoft-specific requirements, binary compatibility (ABI) requirements, and more.
 We're eager to begin accepting features and fixes from the community, but in addition to setting up a CI system, we need
 to write down all of the rules that are currently stored in our brains. (The ABI rules may be useful to other C++
-libraries.) Until that's in place, pull request reviews will be delayed.
+libraries.)
 
 * Issues: **In progress.** We're going to use GitHub issues to track all of the things that we need to work on. This
 includes C++20 features, [LWG issues][], conformance bugs, performance improvements, and other todos. There are

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,15 +4,15 @@
 
 # Checklist
 
+Be sure you've read README.md and understand the scope of this repo.
+
 If you're unsure about a box, leave it unchecked. A maintainer will help you.
 
-- [ ] I understand README.md. I also understand that acceptance of
-  community PRs will be delayed until the test and CI systems are online.
 - [ ] Identifiers in product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
 - [ ] The STL builds successfully and all tests have passed (must be manually
-  verified by an STL maintainer before CI is online, leave this unchecked for
-  initial submission).
+  verified by an STL maintainer before automated testing is enabled on GitHub,
+  leave this unchecked for initial submission).
 - [ ] These changes introduce no known ABI breaks (adding members, renaming
   members, adding virtual functions, changing whether a type is an aggregate
   or trivially copyable, etc.).

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -9,14 +9,6 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-// TRANSITION (for P0768R1 completion):
-// * Implement comparison algorithms from [cmp.alg]
-// * Implement compare_3way and lexicographical_compare_3way in <algorithm>
-// * After completing the above, define __cpp_lib_three_way_comparison when
-//   C++20 and __cpp_impl_three_way_comparison are defined.
-// * Throughput tuning for common_comparison_category
-// * Deprecate rel_ops.
-
 #if _HAS_CXX20
 #include <xtr1common>
 
@@ -39,31 +31,38 @@ enum class _Compare_ncmp : _Compare_t { unordered = -127 };
 // CLASS weak_equality
 class weak_equality {
 public:
-    constexpr explicit weak_equality(const _Compare_eq _Value_) noexcept : _Value(static_cast<_Compare_t>(_Value_)) {}
+    _NODISCARD constexpr explicit weak_equality(const _Compare_eq _Value_) noexcept
+        : _Value(static_cast<_Compare_t>(_Value_)) {}
 
     static const weak_equality equivalent;
     static const weak_equality nonequivalent;
 
-    friend constexpr bool operator==(const weak_equality _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const weak_equality _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
-    }
-    friend constexpr bool operator!=(const weak_equality _Val, _Literal_zero) noexcept {
-        return _Val._Value != 0;
-    }
-
-    friend constexpr bool operator==(_Literal_zero, const weak_equality _Val) noexcept {
-        return _Val._Value == 0;
-    }
-    friend constexpr bool operator!=(_Literal_zero, const weak_equality _Val) noexcept {
-        return _Val._Value != 0;
     }
 
 #ifdef __cpp_impl_three_way_comparison
-    friend constexpr weak_equality operator<=>(const weak_equality _Val, _Literal_zero) noexcept {
+    // This declaration additionally requires P1185, but that proposal has no feature-test macro.
+    _NODISCARD friend constexpr bool operator==(const weak_equality&, const weak_equality&) noexcept = default;
+
+    _NODISCARD friend constexpr weak_equality operator<=>(const weak_equality _Val, _Literal_zero) noexcept {
         return _Val;
     }
-    friend constexpr weak_equality operator<=>(_Literal_zero, const weak_equality _Val) noexcept {
+
+    _NODISCARD friend constexpr weak_equality operator<=>(_Literal_zero, const weak_equality _Val) noexcept {
         return _Val;
+    }
+#else // ^^^ supports <=> and P1185 / supports neither vvv
+    _NODISCARD friend constexpr bool operator!=(const weak_equality _Val, _Literal_zero) noexcept {
+        return _Val._Value != 0;
+    }
+
+    _NODISCARD friend constexpr bool operator==(_Literal_zero, const weak_equality _Val) noexcept {
+        return _Val._Value == 0;
+    }
+
+    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const weak_equality _Val) noexcept {
+        return _Val._Value != 0;
     }
 #endif // __cpp_impl_three_way_comparison
 
@@ -77,7 +76,8 @@ inline constexpr weak_equality weak_equality::nonequivalent(_Compare_eq::nonequi
 // CLASS strong_equality
 class strong_equality {
 public:
-    constexpr explicit strong_equality(const _Compare_eq _Value_) noexcept : _Value(static_cast<_Compare_t>(_Value_)) {}
+    _NODISCARD constexpr explicit strong_equality(const _Compare_eq _Value_) noexcept
+        : _Value(static_cast<_Compare_t>(_Value_)) {}
 
     static const strong_equality equal;
     static const strong_equality nonequal;
@@ -88,26 +88,32 @@ public:
         return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
     }
 
-    friend constexpr bool operator==(const strong_equality _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const strong_equality _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
-    }
-    friend constexpr bool operator!=(const strong_equality _Val, _Literal_zero) noexcept {
-        return _Val._Value != 0;
-    }
-
-    friend constexpr bool operator==(_Literal_zero, const strong_equality _Val) noexcept {
-        return _Val._Value == 0;
-    }
-    friend constexpr bool operator!=(_Literal_zero, const strong_equality _Val) noexcept {
-        return _Val._Value != 0;
     }
 
 #ifdef __cpp_impl_three_way_comparison
-    friend constexpr strong_equality operator<=>(const strong_equality _Val, _Literal_zero) noexcept {
+    // This declaration additionally requires P1185, but that proposal has no feature-test macro.
+    _NODISCARD friend constexpr bool operator==(const strong_equality&, const strong_equality&) noexcept = default;
+
+    _NODISCARD friend constexpr strong_equality operator<=>(const strong_equality _Val, _Literal_zero) noexcept {
         return _Val;
     }
-    friend constexpr strong_equality operator<=>(_Literal_zero, const strong_equality _Val) noexcept {
+
+    _NODISCARD friend constexpr strong_equality operator<=>(_Literal_zero, const strong_equality _Val) noexcept {
         return _Val;
+    }
+#else // ^^^ supports <=> and P1185 / supports neither vvv
+    _NODISCARD friend constexpr bool operator!=(const strong_equality _Val, _Literal_zero) noexcept {
+        return _Val._Value != 0;
+    }
+
+    _NODISCARD friend constexpr bool operator==(_Literal_zero, const strong_equality _Val) noexcept {
+        return _Val._Value == 0;
+    }
+
+    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const strong_equality _Val) noexcept {
+        return _Val._Value != 0;
     }
 #endif // __cpp_impl_three_way_comparison
 
@@ -123,11 +129,11 @@ inline constexpr strong_equality strong_equality::nonequivalent(_Compare_eq::non
 // CLASS partial_ordering
 class partial_ordering {
 public:
-    constexpr explicit partial_ordering(const _Compare_eq _Value_) noexcept
+    _NODISCARD constexpr explicit partial_ordering(const _Compare_eq _Value_) noexcept
         : _Value(static_cast<_Compare_t>(_Value_)), _Is_ordered(true) {}
-    constexpr explicit partial_ordering(const _Compare_ord _Value_) noexcept
+    _NODISCARD constexpr explicit partial_ordering(const _Compare_ord _Value_) noexcept
         : _Value(static_cast<_Compare_t>(_Value_)), _Is_ordered(true) {}
-    constexpr explicit partial_ordering(const _Compare_ncmp _Value_) noexcept
+    _NODISCARD constexpr explicit partial_ordering(const _Compare_ncmp _Value_) noexcept
         : _Value(static_cast<_Compare_t>(_Value_)), _Is_ordered(false) {}
 
     static const partial_ordering less;
@@ -139,49 +145,65 @@ public:
         return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
     }
 
-    friend constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Is_ordered && _Val._Value == 0;
     }
-    friend constexpr bool operator!=(const partial_ordering _Val, _Literal_zero) noexcept {
+
+#ifdef __cpp_impl_three_way_comparison
+    // This declaration additionally requires P1185, but that proposal has no feature-test macro.
+    _NODISCARD friend constexpr bool operator==(const partial_ordering&, const partial_ordering&) noexcept = default;
+#else // ^^^ supports <=> and P1185 / supports neither vvv
+    _NODISCARD friend constexpr bool operator!=(const partial_ordering _Val, _Literal_zero) noexcept {
         return !_Val._Is_ordered || _Val._Value != 0;
     }
-    friend constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator==(_Literal_zero, const partial_ordering _Val) noexcept {
+        return _Val._Is_ordered && 0 == _Val._Value;
+    }
+
+    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const partial_ordering _Val) noexcept {
+        return !_Val._Is_ordered || 0 != _Val._Value;
+    }
+#endif // __cpp_impl_three_way_comparison
+
+    _NODISCARD friend constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Is_ordered && _Val._Value < 0;
     }
-    friend constexpr bool operator>(const partial_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator>(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Is_ordered && _Val._Value > 0;
     }
-    friend constexpr bool operator<=(const partial_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator<=(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Is_ordered && _Val._Value <= 0;
     }
-    friend constexpr bool operator>=(const partial_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator>=(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Is_ordered && _Val._Value >= 0;
     }
 
-    friend constexpr bool operator==(_Literal_zero, const partial_ordering _Val) noexcept {
-        return _Val._Is_ordered && 0 == _Val._Value;
-    }
-    friend constexpr bool operator!=(_Literal_zero, const partial_ordering _Val) noexcept {
-        return !_Val._Is_ordered || _Val._Value != 0;
-    }
-    friend constexpr bool operator<(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val._Is_ordered && 0 < _Val._Value;
     }
-    friend constexpr bool operator>(_Literal_zero, const partial_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator>(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val._Is_ordered && 0 > _Val._Value;
     }
-    friend constexpr bool operator<=(_Literal_zero, const partial_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val._Is_ordered && 0 <= _Val._Value;
     }
-    friend constexpr bool operator>=(_Literal_zero, const partial_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val._Is_ordered && 0 >= _Val._Value;
     }
 
 #ifdef __cpp_impl_three_way_comparison
-    friend constexpr partial_ordering operator<=>(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr partial_ordering operator<=>(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
-    friend constexpr partial_ordering operator<=>(_Literal_zero, const partial_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr partial_ordering operator<=>(_Literal_zero, const partial_ordering _Val) noexcept {
         return partial_ordering{static_cast<_Compare_ord>(-_Val._Value)};
     }
 #endif // __cpp_impl_three_way_comparison
@@ -199,8 +221,10 @@ inline constexpr partial_ordering partial_ordering::unordered(_Compare_ncmp::uno
 // CLASS weak_ordering
 class weak_ordering {
 public:
-    constexpr explicit weak_ordering(const _Compare_eq _Value_) noexcept : _Value(static_cast<_Compare_t>(_Value_)) {}
-    constexpr explicit weak_ordering(const _Compare_ord _Value_) noexcept : _Value(static_cast<_Compare_t>(_Value_)) {}
+    _NODISCARD constexpr explicit weak_ordering(const _Compare_eq _Value_) noexcept
+        : _Value(static_cast<_Compare_t>(_Value_)) {}
+    _NODISCARD constexpr explicit weak_ordering(const _Compare_ord _Value_) noexcept
+        : _Value(static_cast<_Compare_t>(_Value_)) {}
 
     static const weak_ordering less;
     static const weak_ordering equivalent;
@@ -209,53 +233,70 @@ public:
     constexpr operator weak_equality() const noexcept {
         return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
     }
+
     constexpr operator partial_ordering() const noexcept {
         return partial_ordering{static_cast<_Compare_ord>(_Value)};
     }
 
-    friend constexpr bool operator==(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
-    friend constexpr bool operator!=(const weak_ordering _Val, _Literal_zero) noexcept {
+
+#ifdef __cpp_impl_three_way_comparison
+    // This declaration additionally requires P1185, but that proposal has no feature-test macro.
+    _NODISCARD friend constexpr bool operator==(const weak_ordering&, const weak_ordering&) noexcept = default;
+#else // ^^^ supports <=> and P1185 / supports neither vvv
+    _NODISCARD friend constexpr bool operator!=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value != 0;
     }
-    friend constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator==(_Literal_zero, const weak_ordering _Val) noexcept {
+        return 0 == _Val._Value;
+    }
+
+    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const weak_ordering _Val) noexcept {
+        return 0 != _Val._Value;
+    }
+#endif // __cpp_impl_three_way_comparison
+
+    _NODISCARD friend constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
     }
-    friend constexpr bool operator>(const weak_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator>(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
-    friend constexpr bool operator<=(const weak_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator<=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value <= 0;
     }
-    friend constexpr bool operator>=(const weak_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator>=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    friend constexpr bool operator==(_Literal_zero, const weak_ordering _Val) noexcept {
-        return 0 == _Val._Value;
-    }
-    friend constexpr bool operator!=(_Literal_zero, const weak_ordering _Val) noexcept {
-        return 0 != _Val._Value;
-    }
-    friend constexpr bool operator<(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<(_Literal_zero, const weak_ordering _Val) noexcept {
         return 0 < _Val._Value;
     }
-    friend constexpr bool operator>(_Literal_zero, const weak_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator>(_Literal_zero, const weak_ordering _Val) noexcept {
         return 0 > _Val._Value;
     }
-    friend constexpr bool operator<=(_Literal_zero, const weak_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const weak_ordering _Val) noexcept {
         return 0 <= _Val._Value;
     }
-    friend constexpr bool operator>=(_Literal_zero, const weak_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const weak_ordering _Val) noexcept {
         return 0 >= _Val._Value;
     }
 
 #ifdef __cpp_impl_three_way_comparison
-    friend constexpr weak_ordering operator<=>(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr weak_ordering operator<=>(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
-    friend constexpr weak_ordering operator<=>(_Literal_zero, const weak_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr weak_ordering operator<=>(_Literal_zero, const weak_ordering _Val) noexcept {
         return weak_ordering{static_cast<_Compare_ord>(-_Val._Value)};
     }
 #endif // __cpp_impl_three_way_comparison
@@ -271,8 +312,9 @@ inline constexpr weak_ordering weak_ordering::greater(_Compare_ord::greater);
 // CLASS strong_ordering
 class strong_ordering {
 public:
-    constexpr explicit strong_ordering(const _Compare_eq _Value_) noexcept : _Value(static_cast<_Compare_t>(_Value_)) {}
-    constexpr explicit strong_ordering(const _Compare_ord _Value_) noexcept
+    _NODISCARD constexpr explicit strong_ordering(const _Compare_eq _Value_) noexcept
+        : _Value(static_cast<_Compare_t>(_Value_)) {}
+    _NODISCARD constexpr explicit strong_ordering(const _Compare_ord _Value_) noexcept
         : _Value(static_cast<_Compare_t>(_Value_)) {}
 
     static const strong_ordering less;
@@ -283,59 +325,78 @@ public:
     constexpr operator weak_equality() const noexcept {
         return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
     }
+
     constexpr operator strong_equality() const noexcept {
         return strong_equality{static_cast<_Compare_eq>(_Value != 0)};
     }
+
     constexpr operator partial_ordering() const noexcept {
         return partial_ordering{static_cast<_Compare_ord>(_Value)};
     }
+
     constexpr operator weak_ordering() const noexcept {
         return weak_ordering{static_cast<_Compare_ord>(_Value)};
     }
 
-    friend constexpr bool operator==(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
-    friend constexpr bool operator!=(const strong_ordering _Val, _Literal_zero) noexcept {
+
+#ifdef __cpp_impl_three_way_comparison
+    // This declaration additionally requires P1185, but that proposal has no feature-test macro.
+    _NODISCARD friend constexpr bool operator==(const strong_ordering&, const strong_ordering&) noexcept = default;
+#else // ^^^ supports <=> and P1185 / supports neither vvv
+    _NODISCARD friend constexpr bool operator!=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value != 0;
     }
-    friend constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator==(_Literal_zero, const strong_ordering _Val) noexcept {
+        return 0 == _Val._Value;
+    }
+
+    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const strong_ordering _Val) noexcept {
+        return 0 != _Val._Value;
+    }
+#endif // __cpp_impl_three_way_comparison
+
+    _NODISCARD friend constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
     }
-    friend constexpr bool operator>(const strong_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator>(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
-    friend constexpr bool operator<=(const strong_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator<=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value <= 0;
     }
-    friend constexpr bool operator>=(const strong_ordering _Val, _Literal_zero) noexcept {
+
+    _NODISCARD friend constexpr bool operator>=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    friend constexpr bool operator==(_Literal_zero, const strong_ordering _Val) noexcept {
-        return 0 == _Val._Value;
-    }
-    friend constexpr bool operator!=(_Literal_zero, const strong_ordering _Val) noexcept {
-        return 0 != _Val._Value;
-    }
-    friend constexpr bool operator<(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<(_Literal_zero, const strong_ordering _Val) noexcept {
         return 0 < _Val._Value;
     }
-    friend constexpr bool operator>(_Literal_zero, const strong_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator>(_Literal_zero, const strong_ordering _Val) noexcept {
         return 0 > _Val._Value;
     }
-    friend constexpr bool operator<=(_Literal_zero, const strong_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const strong_ordering _Val) noexcept {
         return 0 <= _Val._Value;
     }
-    friend constexpr bool operator>=(_Literal_zero, const strong_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const strong_ordering _Val) noexcept {
         return 0 >= _Val._Value;
     }
 
 #ifdef __cpp_impl_three_way_comparison
-    friend constexpr strong_ordering operator<=>(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr strong_ordering operator<=>(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
-    friend constexpr strong_ordering operator<=>(_Literal_zero, const strong_ordering _Val) noexcept {
+
+    _NODISCARD friend constexpr strong_ordering operator<=>(_Literal_zero, const strong_ordering _Val) noexcept {
         return strong_ordering{static_cast<_Compare_ord>(-_Val._Value)};
     }
 #endif // __cpp_impl_three_way_comparison
@@ -349,23 +410,33 @@ inline constexpr strong_ordering strong_ordering::equal(_Compare_eq::equal);
 inline constexpr strong_ordering strong_ordering::equivalent(_Compare_eq::equivalent);
 inline constexpr strong_ordering strong_ordering::greater(_Compare_ord::greater);
 
-// NAMED COMPARISON FUNCTIONS
-constexpr bool is_eq(const weak_equality _Comp) noexcept {
+// FUNCTION is_eq
+_NODISCARD constexpr bool is_eq(const weak_equality _Comp) noexcept {
     return _Comp == 0;
 }
-constexpr bool is_neq(const weak_equality _Comp) noexcept {
+
+// FUNCTION is_neq
+_NODISCARD constexpr bool is_neq(const weak_equality _Comp) noexcept {
     return _Comp != 0;
 }
-constexpr bool is_lt(const partial_ordering _Comp) noexcept {
+
+// FUNCTION is_lt
+_NODISCARD constexpr bool is_lt(const partial_ordering _Comp) noexcept {
     return _Comp < 0;
 }
-constexpr bool is_lteq(const partial_ordering _Comp) noexcept {
+
+// FUNCTION is_lteq
+_NODISCARD constexpr bool is_lteq(const partial_ordering _Comp) noexcept {
     return _Comp <= 0;
 }
-constexpr bool is_gt(const partial_ordering _Comp) noexcept {
+
+// FUNCTION is_gt
+_NODISCARD constexpr bool is_gt(const partial_ordering _Comp) noexcept {
     return _Comp > 0;
 }
-constexpr bool is_gteq(const partial_ordering _Comp) noexcept {
+
+// FUNCTION is_gteq
+_NODISCARD constexpr bool is_gteq(const partial_ordering _Comp) noexcept {
     return _Comp >= 0;
 }
 
@@ -397,19 +468,7 @@ struct common_comparison_category {
 template <class... _Types>
 using common_comparison_category_t = typename common_comparison_category<_Types...>::type;
 
-#if 0 // Not yet implemented
-    // COMPARISON ALGORITHMS
-template <class _Ty>
-constexpr strong_ordering strong_order(const _Ty& _Left, const _Ty& _Right);
-template <class _Ty>
-constexpr weak_ordering weak_order(const _Ty& _Left, const _Ty& _Right);
-template <class _Ty>
-constexpr partial_ordering partial_order(const _Ty& _Left, const _Ty& _Right);
-template <class _Ty>
-constexpr strong_equality strong_equal(const _Ty& _Left, const _Ty& _Right);
-template <class _Ty>
-constexpr weak_equality weak_equal(const _Ty& _Left, const _Ty& _Right);
-#endif // Not yet implemented
+// Other components not yet implemented
 _STD_END
 
 #pragma pop_macro("new")


### PR DESCRIPTION
# Description



# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
