### PR TITLE
Simplify thread0.cpp and xthrow.cpp. (microsoft#320)

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/any
     ${CMAKE_CURRENT_LIST_DIR}/inc/array
     ${CMAKE_CURRENT_LIST_DIR}/inc/atomic
+    ${CMAKE_CURRENT_LIST_DIR}/inc/bit
     ${CMAKE_CURRENT_LIST_DIR}/inc/bitset
     ${CMAKE_CURRENT_LIST_DIR}/inc/cassert
     ${CMAKE_CURRENT_LIST_DIR}/inc/ccomplex

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <any>
 #include <array>
+#include <bit>
 #include <bitset>
 #include <charconv>
 #include <chrono>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -1,0 +1,33 @@
+// bit standard header (core)
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+#ifndef _BIT_
+#define _BIT_
+#include <yvals_core.h>
+#if _STL_COMPILER_PREPROCESSOR
+#if !_HAS_CXX20
+#pragma message("The contents of <bit> are available only with C++20 or later.")
+#else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+_STD_BEGIN
+enum class endian { little = 0, big = 1, native = little };
+
+_STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+#endif // _HAS_CXX20
+#endif // _STL_COMPILER_PREPROCESSOR
+#endif // _BIT_

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -12,6 +12,9 @@
 #pragma message("The contents of <bit> are available only with C++20 or later.")
 #else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 
+#include <limits>
+#include <type_traits>
+
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
@@ -21,6 +24,121 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 enum class endian { little = 0, big = 1, native = little };
+
+#ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
+template <class _Ty>
+inline constexpr bool _Is_standard_unsigned_integer =
+    _Is_any_of_v<remove_cv_t<_Ty>, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
+
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr bool ispow2(const _Ty _Val) noexcept {
+    return _Val != 0 && (_Val & (_Val - 1)) == 0;
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr _Ty ceil2(const _Ty _Val) noexcept /* strengthened */ {
+    if (_Val == 0) {
+        return 1;
+    }
+
+    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1))));
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr _Ty floor2(const _Ty _Val) noexcept {
+    if (_Val == 0) {
+        return 0;
+    }
+
+    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - 1 - _STD countl_zero(_Val)));
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr _Ty bit_length(const _Ty _Val) noexcept {
+    return static_cast<_Ty>(numeric_limits<_Ty>::digits - _STD countl_zero(_Val));
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr _Ty rotr(_Ty _Val, int _Rotation) noexcept;
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr _Ty rotl(const _Ty _Val, const int _Rotation) noexcept {
+    constexpr auto _Digits = numeric_limits<_Ty>::digits;
+    const auto _Remainder  = _Rotation % _Digits;
+    if (_Remainder > 0) {
+        return static_cast<_Ty>(
+            static_cast<_Ty>(_Val << _Remainder) | static_cast<_Ty>(_Val >> (_Digits - _Remainder)));
+    } else if (_Remainder == 0) {
+        return _Val;
+    } else { // _Remainder < 0
+        return _STD rotr(_Val, -_Remainder);
+    }
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
+_NODISCARD constexpr _Ty rotr(const _Ty _Val, const int _Rotation) noexcept {
+    constexpr auto _Digits = numeric_limits<_Ty>::digits;
+    const auto _Remainder  = _Rotation % _Digits;
+    if (_Remainder > 0) {
+        return static_cast<_Ty>(
+            static_cast<_Ty>(_Val >> _Remainder) | static_cast<_Ty>(_Val << (_Digits - _Remainder)));
+    } else if (_Remainder == 0) {
+        return _Val;
+    } else { // _Remainder < 0
+        return _STD rotl(_Val, -_Remainder);
+    }
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
+_NODISCARD constexpr int countl_zero(const _Ty _Val) noexcept {
+    constexpr int _Digits = numeric_limits<_Ty>::digits;
+    if (_Val == 0) {
+        return _Digits;
+    }
+
+    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
+        return __builtin_clz(_Val) - (numeric_limits<unsigned int>::digits - _Digits);
+    } else {
+        return __builtin_clzll(_Val) - (numeric_limits<unsigned long long>::digits - _Digits);
+    }
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr int countl_one(const _Ty _Val) noexcept {
+    return _STD countl_zero(static_cast<_Ty>(~_Val));
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr int countr_zero(const _Ty _Val) noexcept {
+    if (_Val == 0) {
+        return numeric_limits<_Ty>::digits;
+    }
+
+    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
+        return __builtin_ctz(_Val);
+    } else {
+        return __builtin_ctzll(_Val);
+    }
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled = 0>
+_NODISCARD constexpr int countr_one(const _Ty _Val) noexcept {
+    return _STD countr_zero(static_cast<_Ty>(~_Val));
+}
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled = 0>
+_NODISCARD constexpr int popcount(const _Ty _Val) noexcept {
+    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
+        return __builtin_popcount(_Val);
+    } else {
+        return __builtin_popcountll(_Val);
+    }
+}
+#endif // __cpp_lib_bitops
 
 _STD_END
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -72,11 +72,6 @@ struct negation : bool_constant<!static_cast<bool>(_Trait::value)> {}; // The ne
 template <class _Trait>
 _INLINE_VAR constexpr bool negation_v = negation<_Trait>::value;
 
-#if _HAS_CXX20
-// ENUM CLASS endian
-enum class endian { little = 0, big = 1, native = little };
-#endif // _HAS_CXX20
-
 // STRUCT TEMPLATE _Arg_types
 template <class... _Types>
 struct _Arg_types {}; // provide argument_type, etc. (sometimes)

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -52,6 +52,7 @@
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 //     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
+// P1612R1 Relocating endian To <bit>
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1754R1 Rename Concepts To standard_case
 // P????R? directory_entry::clear_cache()
@@ -959,6 +960,7 @@
 #endif // _HAS_STD_BOOLEAN
 #endif // defined(__cpp_concepts) && __cpp_concepts > 201507L
 
+#define __cpp_lib_endian                   201907L
 #define __cpp_lib_erase_if                 201811L
 #define __cpp_lib_generic_unordered_lookup 201811L
 #define __cpp_lib_list_remove_return_type  201806L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -31,6 +31,9 @@
 //     (mbrtoc8 and c8rtomb not yet implemented)
 // P0487R1 Fixing operator>>(basic_istream&, CharT*)
 // P0550R2 remove_cvref
+// P0553R4 <bit> Rotating And Counting Functions
+// P0556R3 <bit> ispow2(), ceil2(), floor2(), log2p1()
+//            (log2p1() is called bit_length() as of D1956)
 // P0616R0 Using move() In <numeric>
 // P0631R8 <numbers> Math Constants
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
@@ -945,7 +948,13 @@
 
 // C++20
 #if _HAS_CXX20
-#define __cpp_lib_bind_front           201907L
+#define __cpp_lib_bind_front 201907L
+#if defined(__clang__) || defined(__EDG__)
+#define __cpp_lib_bitops 201907L
+#else // ^^^ Clang and EDG / MSVC vvv
+// a future MSVC update will embed CPU feature detection into <bit> intrinsics
+// TRANSITION, VSO-1020212
+#endif // defined(__clang__) || defined(__EDG__)
 #define __cpp_lib_bounded_array_traits 201902L
 #ifdef __cpp_char8_t
 #define __cpp_lib_char8_t 201811L

--- a/stl/src/thread0.cpp
+++ b/stl/src/thread0.cpp
@@ -5,41 +5,37 @@
 
 #include <yvals.h>
 
-#include <mutex>
+#include <stdlib.h>
 #include <system_error>
-#include <thread>
 #include <xthreads.h>
-
-#if _HAS_EXCEPTIONS
-#include <exception>
-#include <string>
-
-#else // _HAS_EXCEPTIONS
-#include <cstdio>
-#endif // _HAS_EXCEPTIONS
-
-static const char* const msgs[] = { // error messages
-    "device or resource busy", "invalid argument", "no such process", "not enough memory", "operation not permitted",
-    "resource deadlock would occur", "resource unavailable try again"};
-
-static const int codes[] = { // system_error codes
-    (int) _STD errc::device_or_resource_busy, (int) _STD errc::invalid_argument, (int) _STD errc::no_such_process,
-    (int) _STD errc::not_enough_memory, (int) _STD errc::operation_not_permitted,
-    (int) _STD errc::resource_deadlock_would_occur, (int) _STD errc::resource_unavailable_try_again};
 
 _STD_BEGIN
 
-#if _HAS_EXCEPTIONS
-_CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int code) { // throw error object
-    throw _STD system_error(codes[code], _STD generic_category(), msgs[code]);
-}
+static constexpr const char* msgs[] = {
+    // error messages
+    "device or resource busy",
+    "invalid argument",
+    "no such process",
+    "not enough memory",
+    "operation not permitted",
+    "resource deadlock would occur",
+    "resource unavailable try again",
+};
 
-#else // _HAS_EXCEPTIONS
-_CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int code) { // report system error
-    _CSTD fputs(msgs[code], stderr);
-    _CSTD abort();
+static constexpr errc codes[] = {
+    // system_error codes
+    errc::device_or_resource_busy,
+    errc::invalid_argument,
+    errc::no_such_process,
+    errc::not_enough_memory,
+    errc::operation_not_permitted,
+    errc::resource_deadlock_would_occur,
+    errc::resource_unavailable_try_again,
+};
+
+[[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int code) { // throw error object
+    _THROW(system_error(static_cast<int>(codes[code]), _STD generic_category(), msgs[code]));
 }
-#endif // _HAS_EXCEPTIONS
 
 [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_C_error(int code) { // throw error object for C error
     switch (code) { // select the exception

--- a/stl/src/xthrow.cpp
+++ b/stl/src/xthrow.cpp
@@ -3,60 +3,43 @@
 
 // exception handling support functions
 
+#include <functional>
 #include <new>
+#include <regex>
 #include <stdexcept>
 
 _STD_BEGIN
 
     [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL
-    _Xbad_alloc() { // report a bad_alloc error
+    _Xbad_alloc() {
     _THROW(bad_alloc{});
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xinvalid_argument(
-    _In_z_ const char* _Message) { // report an invalid_argument error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xinvalid_argument(_In_z_ const char* const _Message) {
     _THROW(invalid_argument(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xlength_error(
-    _In_z_ const char* _Message) { // report a length_error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xlength_error(_In_z_ const char* const _Message) {
     _THROW(length_error(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xout_of_range(
-    _In_z_ const char* _Message) { // report an out_of_range error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xout_of_range(_In_z_ const char* const _Message) {
     _THROW(out_of_range(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xoverflow_error(
-    _In_z_ const char* _Message) { // report an overflow error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xoverflow_error(_In_z_ const char* const _Message) {
     _THROW(overflow_error(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xruntime_error(
-    _In_z_ const char* _Message) { // report a runtime_error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xruntime_error(_In_z_ const char* const _Message) {
     _THROW(runtime_error(_Message));
 }
-_STD_END
 
-#include <functional>
-
-_STD_BEGIN
-
-    [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL
-    _Xbad_function_call() { // report a bad_function_call error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xbad_function_call() {
     _THROW(bad_function_call{});
 }
-_STD_END
 
-#if _HAS_EXCEPTIONS
-#include <regex>
-
-_STD_BEGIN
-
-    [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL
-    _Xregex_error(regex_constants::error_type _Code) { // report a regex_error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xregex_error(const regex_constants::error_type _Code) {
     _THROW(regex_error(_Code));
 }
 _STD_END
-#endif // _HAS_EXCEPTIONS


### PR DESCRIPTION
# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
