### PR TITLE
[range.iter.ops], default_sentinel, and unreachable_sentinel (microso…

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1791,6 +1791,74 @@ _NODISCARD _FwdIt unique(_ExPo&&, _FwdIt _First, _FwdIt _Last) noexcept /* termi
 #endif // _HAS_CXX17
 
 // FUNCTION TEMPLATE unique_copy
+#if _HAS_IF_CONSTEXPR
+// clang-format off
+#ifdef __cpp_lib_concepts
+template <class _InIt, class _OutIt>
+concept _Can_reread_dest = forward_iterator<_OutIt> && same_as<iter_value_t<_InIt>, iter_value_t<_OutIt>>;
+#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
+template <class _InIt, class _OutIt>
+_INLINE_VAR constexpr bool _Can_reread_dest =
+    _Is_fwd_iter_v<_OutIt> && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
+#endif // __cpp_lib_concepts
+// clang-format on
+
+template <class _InIt, class _OutIt, class _Pr>
+_OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) { // copy compressing pairs that match
+    _Adl_verify_range(_First, _Last);
+
+    auto _UFirst      = _Get_unwrapped(_First);
+    const auto _ULast = _Get_unwrapped(_Last);
+
+    if (_UFirst == _ULast) {
+        return _Dest;
+    }
+
+    auto _UDest = _Get_unwrapped_unverified(_Dest);
+
+    if constexpr (_Is_fwd_iter_v<_InIt>) { // can reread the source for comparison
+        auto _Firstb = _UFirst;
+
+        *_UDest = *_Firstb;
+        ++_UDest;
+
+        while (++_UFirst != _ULast) {
+            if (!static_cast<bool>(_Pred(*_Firstb, *_UFirst))) { // copy unmatched
+                _Firstb = _UFirst;
+                *_UDest = *_Firstb;
+                ++_UDest;
+            }
+        }
+    } else if constexpr (_Can_reread_dest<_InIt, _OutIt>) { // assignment copies T; can reread dest for comparison
+        *_UDest = *_UFirst;
+
+        while (++_UFirst != _ULast) {
+            if (!static_cast<bool>(_Pred(*_UDest, *_UFirst))) {
+                *++_UDest = *_UFirst;
+            }
+        }
+
+        ++_UDest;
+    } else { // can't reread source or dest, construct a temporary
+        _Iter_value_t<_InIt> _Val = *_UFirst;
+
+        *_UDest = _Val;
+        ++_UDest;
+
+        while (++_UFirst != _ULast) {
+            if (!static_cast<bool>(_Pred(_Val, *_UFirst))) { // copy unmatched
+                _Val    = *_UFirst;
+                *_UDest = _Val;
+                ++_UDest;
+            }
+        }
+    }
+
+    _Seek_wrapped(_Dest, _UDest);
+    return _Dest;
+}
+
+#else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
 template <class _FwdIt, class _OutIt, class _Pr>
 _OutIt _Unique_copy_unchecked(_FwdIt _First, _FwdIt _Last, _OutIt _Dest, _Pr _Pred, true_type, _Any_tag) {
     // copy compressing pairs satisfying _Pred, forward source iterator
@@ -1865,6 +1933,7 @@ _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) { // copy
 
     return _Dest;
 }
+#endif // _HAS_IF_CONSTEXPR
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _Pr>

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -180,7 +180,7 @@ namespace ranges {
 // CONCEPT swappable
 template <class _Ty>
 concept swappable = requires(_Ty& __x, _Ty& __y) {
-    _STD ranges::swap(__x, __y);
+    _RANGES swap(__x, __y);
 };
 
 // CONCEPT swappable_with
@@ -192,10 +192,10 @@ concept swappable_with =
     common_reference_with<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>
 #endif // select LWG-3175 vs. N4810
     && requires(_Ty1&& __t, _Ty2&& __u) {
-        _STD ranges::swap(static_cast<_Ty1&&>(__t), static_cast<_Ty1&&>(__t));
-        _STD ranges::swap(static_cast<_Ty2&&>(__u), static_cast<_Ty2&&>(__u));
-        _STD ranges::swap(static_cast<_Ty1&&>(__t), static_cast<_Ty2&&>(__u));
-        _STD ranges::swap(static_cast<_Ty2&&>(__u), static_cast<_Ty1&&>(__t));
+        _RANGES swap(static_cast<_Ty1&&>(__t), static_cast<_Ty1&&>(__t));
+        _RANGES swap(static_cast<_Ty2&&>(__u), static_cast<_Ty2&&>(__u));
+        _RANGES swap(static_cast<_Ty1&&>(__t), static_cast<_Ty2&&>(__u));
+        _RANGES swap(static_cast<_Ty2&&>(__u), static_cast<_Ty1&&>(__t));
     };
 
 // CONCEPT copy_constructible

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -833,8 +833,9 @@ struct _Static_partition_range;
 template <class _RanIt, class _Diff>
 struct _Static_partition_range<_RanIt, _Diff, true> {
     using _Target_diff = _Iter_diff_t<_RanIt>;
-    _Unwrapped_t<_RanIt> _Start_at;
-    using _Chunk_type = _Iterator_range<_Unwrapped_t<_RanIt>>;
+    using _URanIt      = _Unwrapped_t<const _RanIt&>;
+    _URanIt _Start_at;
+    using _Chunk_type = _Iterator_range<_URanIt>;
 
     _RanIt _Populate(const _Static_partition_team<_Diff>& _Team,
         _RanIt _First) { // statically partition a random-access iterator range and return next(_First, _Team._Count)
@@ -852,7 +853,7 @@ struct _Static_partition_range<_RanIt, _Diff, true> {
         return _Team._Count == _Last - _First;
     }
 
-    _Unwrapped_t<_RanIt> _Get_first(size_t /* _Chunk_number */,
+    _URanIt _Get_first(size_t /* _Chunk_number */,
         const _Diff _Offset) { // get the first iterator for _Chunk _Chunk_number (which is at offset _Offset)
         return _Start_at + static_cast<_Target_diff>(_Offset);
     }
@@ -868,8 +869,9 @@ struct _Static_partition_range<_RanIt, _Diff, true> {
 template <class _FwdIt, class _Diff>
 struct _Static_partition_range<_FwdIt, _Diff, false> {
     using _Target_diff = _Iter_diff_t<_FwdIt>;
-    _Parallel_vector<_Unwrapped_t<_FwdIt>> _Division_points;
-    using _Chunk_type = _Iterator_range<_Unwrapped_t<_FwdIt>>;
+    using _UFwdIt      = _Unwrapped_t<const _FwdIt&>;
+    _Parallel_vector<_UFwdIt> _Division_points;
+    using _Chunk_type = _Iterator_range<_UFwdIt>;
 
     _FwdIt _Populate(const _Static_partition_team<_Diff>& _Team,
         _FwdIt _First) { // statically partition a forward iterator range and return next(_First, _Team._Count)
@@ -933,7 +935,7 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
         return _First == _Last;
     }
 
-    _Unwrapped_t<_FwdIt> _Get_first(const size_t _Chunk_number, _Diff /* _Offset */) {
+    _UFwdIt _Get_first(const size_t _Chunk_number, _Diff /* _Offset */) {
         // get the first iterator for _Chunk _Chunk_number (which is at offset _Offset)
         return _Division_points[_Chunk_number];
     }
@@ -952,8 +954,8 @@ struct _Static_partition_range_backward;
 template <class _RanIt, class _Diff>
 struct _Static_partition_range_backward<_RanIt, _Diff, true> {
     using _Target_diff = _Iter_diff_t<_RanIt>;
-    _Unwrapped_t<_RanIt> _Start_at;
-    using _Chunk_type = _Iterator_range<_Unwrapped_t<_RanIt>>;
+    _Unwrapped_t<const _RanIt&> _Start_at;
+    using _Chunk_type = _Iterator_range<_Unwrapped_t<const _RanIt&>>;
 
     void _Populate(const _Static_partition_team<_Diff>& _Team, _RanIt _Last) {
         // statically partition a random-access iterator range ending at _Last
@@ -972,8 +974,8 @@ struct _Static_partition_range_backward<_RanIt, _Diff, true> {
 template <class _BidIt, class _Diff>
 struct _Static_partition_range_backward<_BidIt, _Diff, false> {
     using _Target_diff = _Iter_diff_t<_BidIt>;
-    _Parallel_vector<_Unwrapped_t<_BidIt>> _Division_points;
-    using _Chunk_type = _Iterator_range<_Unwrapped_t<_BidIt>>;
+    _Parallel_vector<_Unwrapped_t<const _BidIt&>> _Division_points;
+    using _Chunk_type = _Iterator_range<_Unwrapped_t<const _BidIt&>>;
 
     void _Populate(const _Static_partition_team<_Diff>& _Team, _BidIt _Last) {
         // statically partition a bidirectional iterator range ending at _Last
@@ -1364,7 +1366,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept /* terminates */ {
     // find first matching _Val
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    using _UFwdIt = _Unwrapped_t<_FwdIt>;
+    using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First,
         _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
@@ -1377,7 +1379,7 @@ template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_E
 _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying _Pred
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    using _UFwdIt = _Unwrapped_t<_FwdIt>;
+    using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _Pass_fn(_Pred);
     _Seek_wrapped(_First,
@@ -1391,7 +1393,7 @@ template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_E
 _NODISCARD _FwdIt find_if_not(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying !_Pred
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    using _UFwdIt = _Unwrapped_t<_FwdIt>;
+    using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _Pass_fn(_Pred);
     _Seek_wrapped(_First, _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First),
@@ -1606,7 +1608,7 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
     const _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // look for one of [_First2, _Last2) that matches element
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    using _UFwdIt1 = _Unwrapped_t<_FwdIt1>;
+    using _UFwdIt1 = _Unwrapped_t<const _FwdIt1&>;
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst2 = _Get_unwrapped(_First2);
@@ -1768,8 +1770,9 @@ _NODISCARD _Iter_diff_t<_FwdIt> count(
 }
 
 // PARALLEL FUNCTION TEMPLATE mismatch
-template <class _FwdIt1, class _FwdIt2, bool = _Use_atomic_iterator<_Unwrapped_t<_FwdIt1>>&& _Is_random_iter_v<_FwdIt2>,
-    bool = _Use_atomic_iterator<_Unwrapped_t<_FwdIt2>>&& _Is_random_iter_v<_FwdIt1>>
+template <class _FwdIt1, class _FwdIt2,
+    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt1&>>&& _Is_random_iter_v<_FwdIt2>,
+    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt2&>>&& _Is_random_iter_v<_FwdIt1>>
 struct _Static_partitioned_mismatch_results;
 
 template <class _FwdIt1, class _FwdIt2, bool _Unused>
@@ -1777,9 +1780,10 @@ struct _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2, true, _Unused> {
     // atomically manipulate atomic<_FwdIt1> and calculate the second iterator by adding distance to it
     _Parallel_choose_min_result<_FwdIt1> _Storage;
 
-    _Static_partitioned_mismatch_results(const _FwdIt1 _Last1, const _Unwrapped_t<_FwdIt2>&) : _Storage(_Last1) {}
+    _Static_partitioned_mismatch_results(const _FwdIt1 _Last1, const _Unwrapped_t<const _FwdIt2&>&)
+        : _Storage(_Last1) {}
 
-    void _Imbue(const size_t _Chunk_number, const _FwdIt1 _First1, const _Unwrapped_t<_FwdIt2>&) {
+    void _Imbue(const size_t _Chunk_number, const _FwdIt1 _First1, const _Unwrapped_t<const _FwdIt2&>&) {
         _Storage._Imbue(_Chunk_number, _First1);
     }
 
@@ -1794,9 +1798,10 @@ struct _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2, false, true> {
     // atomically manipulate atomic<_FwdIt2> and calculate the first iterator by adding distance to it
     _Parallel_choose_min_result<_FwdIt2> _Storage;
 
-    _Static_partitioned_mismatch_results(const _Unwrapped_t<_FwdIt1>&, const _FwdIt2 _Last2) : _Storage(_Last2) {}
+    _Static_partitioned_mismatch_results(const _Unwrapped_t<const _FwdIt1&>&, const _FwdIt2 _Last2)
+        : _Storage(_Last2) {}
 
-    void _Imbue(const size_t _Chunk_number, const _Unwrapped_t<_FwdIt1>&, const _FwdIt2 _First2) {
+    void _Imbue(const size_t _Chunk_number, const _Unwrapped_t<const _FwdIt1&>&, const _FwdIt2 _First2) {
         _Storage._Imbue(_Chunk_number, _First2);
     }
 
@@ -1809,12 +1814,13 @@ struct _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2, false, true> {
 template <class _FwdIt1, class _FwdIt2>
 struct _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2, false, false> {
     // get both iterators by manipulating them under lock
-    _Parallel_choose_min_chunk<pair<_Unwrapped_t<_FwdIt1>, _Unwrapped_t<_FwdIt2>>> _Storage;
+    using _UFwdIt1 = _Unwrapped_t<const _FwdIt1&>;
+    using _UFwdIt2 = _Unwrapped_t<const _FwdIt2&>;
+    _Parallel_choose_min_chunk<pair<_UFwdIt1, _UFwdIt2>> _Storage;
 
-    _Static_partitioned_mismatch_results(const _Unwrapped_t<_FwdIt1> _Last1, const _Unwrapped_t<_FwdIt2> _Last2)
-        : _Storage({_Last1, _Last2}) {}
+    _Static_partitioned_mismatch_results(const _UFwdIt1 _Last1, const _UFwdIt2 _Last2) : _Storage({_Last1, _Last2}) {}
 
-    void _Imbue(const size_t _Chunk_number, const _Unwrapped_t<_FwdIt1> _First1, const _Unwrapped_t<_FwdIt2> _First2) {
+    void _Imbue(const size_t _Chunk_number, const _UFwdIt1 _First1, const _UFwdIt2 _First2) {
         _Storage._Imbue(_Chunk_number, {_First1, _First2});
     }
 
@@ -4055,7 +4061,7 @@ _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2
 template <class _InIt, class _Ty, class _BinOp>
 _Ty _Reduce_move_unchecked(_InIt _First, const _InIt _Last, _Ty _Val, _BinOp _Reduce_op) {
     // return reduction, choose optimization
-    if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<_InIt>, _Ty, _BinOp>) {
+    if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<const _InIt&>, _Ty, _BinOp>) {
         (void) _Reduce_op; // TRANSITION, VSO-486357
         return _Reduce_plus_arithmetic_ranges(_First, _Last, _Val);
     } else {
@@ -4626,7 +4632,7 @@ _FwdIt2 inclusive_scan(
             if (_Count >= 2) { // ... with at least 2 elements
                 _TRY_BEGIN
                 auto _Passed_op = _Pass_fn(_Reduce_op);
-                _Static_partitioned_inclusive_scan2<_Ty, _Ty, _Unwrapped_t<_FwdIt1>, decltype(_UDest),
+                _Static_partitioned_inclusive_scan2<_Ty, _Ty, _Unwrapped_t<const _FwdIt1&>, decltype(_UDest),
                     decltype(_Passed_op)>
                     _Operation{_Hw_threads, _Count, _Passed_op, _Val};
                 _Operation._Basis1._Populate(_Operation._Team, _UFirst);
@@ -4670,7 +4676,7 @@ _FwdIt2 inclusive_scan(
                 _TRY_BEGIN
                 _No_init_tag _Tag;
                 auto _Passed_op = _Pass_fn(_Reduce_op);
-                _Static_partitioned_inclusive_scan2<_Iter_value_t<_FwdIt1>, _No_init_tag, _Unwrapped_t<_FwdIt1>,
+                _Static_partitioned_inclusive_scan2<_Iter_value_t<_FwdIt1>, _No_init_tag, _Unwrapped_t<const _FwdIt1&>,
                     decltype(_UDest), decltype(_Passed_op)>
                     _Operation{_Hw_threads, _Count, _Passed_op, _Tag};
                 _Operation._Basis1._Populate(_Operation._Team, _UFirst);
@@ -4962,7 +4968,7 @@ _FwdIt2 transform_inclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _L
                 _TRY_BEGIN
                 auto _Passed_reduce    = _Pass_fn(_Reduce_op);
                 auto _Passed_transform = _Pass_fn(_Transform_op);
-                _Static_partitioned_transform_inclusive_scan2<_Ty, _Ty, _Unwrapped_t<_FwdIt1>, decltype(_UDest),
+                _Static_partitioned_transform_inclusive_scan2<_Ty, _Ty, _Unwrapped_t<const _FwdIt1&>, decltype(_UDest),
                     decltype(_Passed_reduce), decltype(_Passed_transform)>
                     _Operation{_Hw_threads, _Count, _Passed_reduce, _Passed_transform, _Val};
                 _Operation._Basis1._Populate(_Operation._Team, _UFirst);
@@ -5010,8 +5016,9 @@ _FwdIt2 transform_inclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _L
                 auto _Passed_reduce    = _Pass_fn(_Reduce_op);
                 auto _Passed_transform = _Pass_fn(_Transform_op);
                 using _Intermediate_t  = decay_t<decltype(_Transform_op(*_UFirst))>;
-                _Static_partitioned_transform_inclusive_scan2<_Intermediate_t, _No_init_tag, _Unwrapped_t<_FwdIt1>,
-                    decltype(_UDest), decltype(_Passed_reduce), decltype(_Passed_transform)>
+                _Static_partitioned_transform_inclusive_scan2<_Intermediate_t, _No_init_tag,
+                    _Unwrapped_t<const _FwdIt1&>, decltype(_UDest), decltype(_Passed_reduce),
+                    decltype(_Passed_transform)>
                     _Operation{_Hw_threads, _Count, _Passed_reduce, _Passed_transform, _Tag};
                 _Operation._Basis1._Populate(_Operation._Team, _UFirst);
                 _Seek_wrapped(_Dest, _Operation._Basis2._Populate(_Operation._Team, _UDest));

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -279,9 +279,9 @@ namespace filesystem {
     template <class _Src>
     _NODISCARD auto _Stringoid_from_Source(const _Src& _Source) {
         using _EcharT = _Iter_value_t<decay_t<_Src>>;
-        if constexpr (is_pointer_v<_Unwrapped_unverified_t<_Src>>) {
+        if constexpr (is_pointer_v<_Unwrapped_unverified_t<const _Src&>>) {
             return basic_string_view<_EcharT>(_Get_unwrapped_unverified(_Source));
-        } else if constexpr (is_pointer_v<_Unwrapped_t<_Src>>) {
+        } else if constexpr (is_pointer_v<_Unwrapped_t<const _Src&>>) {
             const auto _Data = _Get_unwrapped(_Source);
             auto _Next       = _Source;
             while (*_Next != _EcharT{}) {
@@ -1582,8 +1582,8 @@ namespace filesystem {
 
         using _Prevent_inheriting_unwrap = _Path_iterator;
 
-        template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
-        _NODISCARD _Path_iterator<_Unwrapped_t<_Base_iter>> _Unwrapped() const {
+        template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
+        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const {
             return {_Position._Unwrapped(), _Element.native(), _Mypath};
         }
 
@@ -1592,7 +1592,7 @@ namespace filesystem {
         template <class _Other>
         friend class _Path_iterator;
 
-        template <class _Other, enable_if_t<_Wrapped_seekable_v<_Base_iter, _Other>, int> = 0>
+        template <class _Other, enable_if_t<_Wrapped_seekable_v<_Base_iter, const _Other&>, int> = 0>
         constexpr void _Seek_to(const _Path_iterator<_Other>& _It) {
             _Position._Seek_to(_It._Position);
             _Element = _It._Element;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -949,6 +949,13 @@ private:
 };
 #pragma warning(pop)
 
+// TRANSITION, Visual Studio 2019 16.5 + CUDA
+#if (defined(_MSC_VER) && _MSC_VER < 1925) || defined(__CUDACC__)
+#define _USE_FUNCTION_INT_0_SFINAE 0
+#else
+#define _USE_FUNCTION_INT_0_SFINAE 1
+#endif // (defined(_MSC_VER) && _MSC_VER < 1925) || defined(__CUDACC__)
+
 // CLASS TEMPLATE _Func_class
 template <class _Ret, class... _Types>
 class _Func_class : public _Arg_types<_Types...> {
@@ -976,7 +983,8 @@ public:
 protected:
     template <class _Fx, class _Function>
     using _Enable_if_callable_t =
-        enable_if_t<conjunction_v<negation<is_same<decay_t<_Fx>, _Function>>, _Is_invocable_r<_Ret, _Fx, _Types...>>>;
+        enable_if_t<conjunction_v<negation<is_same<decay_t<_Fx>, _Function>>, _Is_invocable_r<_Ret, _Fx, _Types...>>,
+            int>;
 
     bool _Empty() const noexcept {
         return !_Getimpl();
@@ -1125,7 +1133,11 @@ public:
         this->_Reset_copy(_Right);
     }
 
+#if _USE_FUNCTION_INT_0_SFINAE
+    template <class _Fx, typename _Mybase::template _Enable_if_callable_t<_Fx&, function> = 0>
+#else // ^^^ _USE_FUNCTION_INT_0_SFINAE // !_USE_FUNCTION_INT_0_SFINAE vvv
     template <class _Fx, class = typename _Mybase::template _Enable_if_callable_t<_Fx&, function>>
+#endif // _USE_FUNCTION_INT_0_SFINAE
     function(_Fx _Func) {
         this->_Reset(_STD move(_Func));
     }
@@ -1142,7 +1154,11 @@ public:
         this->_Reset_alloc(_Right, _Ax);
     }
 
+#if _USE_FUNCTION_INT_0_SFINAE
+    template <class _Fx, class _Alloc, typename _Mybase::template _Enable_if_callable_t<_Fx&, function> = 0>
+#else // ^^^ _USE_FUNCTION_INT_0_SFINAE // !_USE_FUNCTION_INT_0_SFINAE vvv
     template <class _Fx, class _Alloc, class = typename _Mybase::template _Enable_if_callable_t<_Fx&, function>>
+#endif // _USE_FUNCTION_INT_0_SFINAE
     function(allocator_arg_t, const _Alloc& _Ax, _Fx _Func) {
         this->_Reset_alloc(_STD move(_Func), _Ax);
     }
@@ -1172,7 +1188,11 @@ public:
         return *this;
     }
 
+#if _USE_FUNCTION_INT_0_SFINAE
+    template <class _Fx, typename _Mybase::template _Enable_if_callable_t<decay_t<_Fx>&, function> = 0>
+#else // ^^^ _USE_FUNCTION_INT_0_SFINAE // !_USE_FUNCTION_INT_0_SFINAE vvv
     template <class _Fx, class = typename _Mybase::template _Enable_if_callable_t<decay_t<_Fx>&, function>>
+#endif // _USE_FUNCTION_INT_0_SFINAE
     function& operator=(_Fx&& _Func) {
         function(_STD forward<_Fx>(_Func)).swap(*this);
         return *this;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1726,7 +1726,7 @@ struct _Boyer_moore_hash_delta_1_table { // stores the Boyer-Moore delta_1 table
     using _Value_t = _Iter_value_t<_RanItPat>;
     using _Diff    = _Iter_diff_t<_RanItPat>;
 
-    _Boyer_moore_hash_delta_1_table(_RanItPat _Pat_first_arg, _Unwrapped_t<_RanItPat> _UPat_first,
+    _Boyer_moore_hash_delta_1_table(_RanItPat _Pat_first_arg, _Unwrapped_t<const _RanItPat&> _UPat_first,
         const _Diff _Pat_size_arg, _Hash_ty&& _Hash_fn, _Pred_eq&& _Eq)
         : _Pat_first(_Pat_first_arg), _Pat_size(_Pat_size_arg),
           _Map(0, _STD move(_Hash_fn), _STD move(_Eq)) { // initialize a delta_1 hash table
@@ -1763,7 +1763,7 @@ struct _Boyer_moore_flat_delta_1_table { // stores the Boyer-Moore delta_1 table
     using _Value_t = _Iter_value_t<_RanItPat>;
     using _Diff    = _Iter_diff_t<_RanItPat>;
 
-    _Boyer_moore_flat_delta_1_table(_RanItPat _Pat_first_arg, _Unwrapped_t<_RanItPat> _UPat_first,
+    _Boyer_moore_flat_delta_1_table(_RanItPat _Pat_first_arg, _Unwrapped_t<const _RanItPat&> _UPat_first,
         const _Diff _Pat_size_arg, _Unused_parameter, _Unused_parameter)
         : _Pat_first(_Pat_first_arg), _Pat_size(_Pat_size_arg) { // initialize a delta_1 flat table
         _STD fill(_STD begin(_Table), _STD end(_Table), _Pat_size);

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -256,11 +256,11 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);
-        if constexpr (_Fill_memset_is_safe<_Unwrapped_n_t<_NoThrowFwdIt>, _Tval>) {
+        if constexpr (_Fill_memset_is_safe<_Unwrapped_n_t<const _NoThrowFwdIt&>, _Tval>) {
             _CSTD memset(_UFirst, static_cast<unsigned char>(_Val), _Count);
             _UFirst += _Count;
         } else {
-            _Uninitialized_backout<_Unwrapped_n_t<_NoThrowFwdIt>> _Backout{_UFirst};
+            _Uninitialized_backout<_Unwrapped_n_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
             for (; 0 < _Count; --_Count) {
                 _Backout._Emplace_back(_Val);
             }
@@ -299,8 +299,8 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
     // copy _Count copies of _Val to raw _First
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
-        const auto _UFirst = _Get_unwrapped_n(_First, _Count);
-        _Seek_wrapped(_First, _Uninitialized_fill_n_unchecked1(_UFirst, _Count, _Val,
+        auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+        _Seek_wrapped(_First, _Uninitialized_fill_n_unchecked1(_STD move(_UFirst), _Count, _Val,
                                   bool_constant<_Fill_memset_is_safe<_Unwrapped_t<_NoThrowFwdIt>, _Tval>>{}));
     }
 
@@ -391,7 +391,7 @@ void uninitialized_value_construct(const _NoThrowFwdIt _First, const _NoThrowFwd
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
-    if constexpr (_Use_memset_value_construct_v<_Unwrapped_t<_NoThrowFwdIt>>) {
+    if constexpr (_Use_memset_value_construct_v<_Unwrapped_t<const _NoThrowFwdIt&>>) {
         _Zero_range(_UFirst, _ULast);
     } else {
         _Uninitialized_backout _Backout{_UFirst};

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -75,7 +75,7 @@ _NODISCARD _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val, _BinOp _R
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<_InIt>, _Ty, _BinOp>) {
+    if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<const _InIt&>, _Ty, _BinOp>) {
         (void) _Reduce_op; // TRANSITION, VSO-486357
         return _Reduce_plus_arithmetic_ranges(_UFirst, _ULast, _Val);
     } else {
@@ -200,7 +200,8 @@ _NODISCARD _Ty transform_reduce(
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
     auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
-    if constexpr (_Default_ops_transform_reduce_v<_Unwrapped_t<_InIt1>, _Unwrapped_t<_InIt2>, _Ty, _BinOp1, _BinOp2>) {
+    if constexpr (_Default_ops_transform_reduce_v<_Unwrapped_t<const _InIt1&>, _Unwrapped_t<const _InIt2&>, _Ty,
+                      _BinOp1, _BinOp2>) {
         (void) _Reduce_op; // TRANSITION, VSO-486357
         (void) _Transform_op; // TRANSITION, VSO-486357
         return _Transform_reduce_arithmetic_defaults(_UFirst1, _ULast1, _UFirst2, _STD move(_Val));

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2173,7 +2173,8 @@ _NODISCARD bool regex_match(_BidIt _First, _BidIt _Last, const basic_regex<_Elem
     // try to match regular expression to target text
     _Adl_verify_range(_First, _Last);
     return _Regex_match1(_Get_unwrapped(_First), _Get_unwrapped(_Last),
-        static_cast<match_results<_Unwrapped_t<_BidIt>>*>(nullptr), _Re, _Flgs | regex_constants::match_any, true);
+        static_cast<match_results<_Unwrapped_t<const _BidIt&>>*>(nullptr), _Re, _Flgs | regex_constants::match_any,
+        true);
 }
 
 template <class _Elem, class _RxTraits>
@@ -2272,7 +2273,7 @@ _NODISCARD bool regex_search(_BidIt _First, _BidIt _Last, const basic_regex<_Ele
     // search for regular expression match in target text
     _Adl_verify_range(_First, _Last);
     return _Regex_search2(_Get_unwrapped(_First), _Get_unwrapped(_Last),
-        static_cast<match_results<_Unwrapped_t<_BidIt>>*>(nullptr), _Re, _Flgs | regex_constants::match_any,
+        static_cast<match_results<_Unwrapped_t<const _BidIt&>>*>(nullptr), _Re, _Flgs | regex_constants::match_any,
         _Get_unwrapped(_First));
 }
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1218,7 +1218,8 @@ using _Conditional_type = decltype(false ? _STD declval<_Ty1>() : _STD declval<_
 template <class _Ty1, class _Ty2, class = void>
 struct _Const_lvalue_cond_oper {};
 
-// N4810 [meta.trans.other]/3.3.4 (per P/R of LWG-3205): "Otherwise, if remove_cvref_t</**/> denotes a type..."
+// N4810 [meta.trans.other]/3.3.4 (per the proposed resolution of LWG-3205): "Otherwise, if remove_cvref_t</**/> denotes
+// a type..."
 template <class _Ty1, class _Ty2>
 struct _Const_lvalue_cond_oper<_Ty1, _Ty2, void_t<_Conditional_type<const _Ty1&, const _Ty2&>>> {
     using type = remove_cvref_t<_Conditional_type<const _Ty1&, const _Ty2&>>;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1764,10 +1764,10 @@ void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, c
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    if constexpr (_Fill_memset_is_safe<_Unwrapped_t<_NoThrowFwdIt>, _Tval>) {
+    if constexpr (_Fill_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>) {
         _CSTD memset(_UFirst, static_cast<unsigned char>(_Val), static_cast<size_t>(_ULast - _UFirst));
     } else {
-        _Uninitialized_backout<_Unwrapped_t<_NoThrowFwdIt>> _Backout{_UFirst};
+        _Uninitialized_backout<_Unwrapped_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
         while (_Backout._Last != _ULast) {
             _Backout._Emplace_back(_Val);
         }
@@ -1801,7 +1801,7 @@ void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, c
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     _Uninitialized_fill_unchecked(_UFirst, _Get_unwrapped(_Last), _Val,
-        bool_constant<_Fill_memset_is_safe<_Unwrapped_t<_NoThrowFwdIt>, _Tval>>{});
+        bool_constant<_Fill_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -312,7 +312,7 @@ template <class>
 struct _Cond_value_type {};
 
 // clang-format off
-template<class _Ty>
+template <class _Ty>
     requires is_object_v<_Ty>
 struct _Cond_value_type<_Ty> {
     using value_type = remove_cv_t<_Ty>;
@@ -411,8 +411,21 @@ concept _Cpp17_input_iterator = _Cpp17_iterator<_It> && equality_comparable<_It>
         requires signed_integral<typename incrementable_traits<_It>::difference_type>;
     };
 
+#if 1 // TRANSITION, VSO-1002863
+template <class _Ty>
+using _Member_iterator_category = typename _Ty::iterator_category;
+#endif // TRANSITION, VSO-1002863
+
 template <class _It>
-    requires (!_Has_iter_types<_It> && _Cpp17_iterator<_It> && !_Cpp17_input_iterator<_It>)
+    requires (!_Has_iter_types<_It> && _Cpp17_iterator<_It> && !_Cpp17_input_iterator<_It>
+        // Implements the proposed resolution of LWG-3283:
+#if 1 // TRANSITION, VSO-1002863
+        && (!requires { typename _It::iterator_category; }
+            || derived_from<_Member_iterator_category<_It>, output_iterator_tag>))
+#else // ^^^ workaround / no workaround vvv
+        && (!requires { typename _It::iterator_category; }
+            || derived_from<typename _It::iterator_category, output_iterator_tag>))
+#endif // TRANSITION, VSO-1002863
 struct _Iterator_traits_base<_It> {
     using iterator_category = output_iterator_tag;
     using difference_type =
@@ -619,15 +632,15 @@ namespace ranges {
         public:
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Custom) {
-                    return iter_move(static_cast<_Ty&&>(__t));
+                    return iter_move(static_cast<_Ty&&>(_Val));
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Fallback) {
-                    using _Ref = decltype(*static_cast<_Ty&&>(__t));
+                    using _Ref = decltype(*static_cast<_Ty&&>(_Val));
                     if constexpr (is_lvalue_reference_v<_Ref>) {
-                        return _STD move(*static_cast<_Ty&&>(__t));
+                        return _STD move(*static_cast<_Ty&&>(_Val));
                     } else {
-                        return *static_cast<_Ty&&>(__t);
+                        return *static_cast<_Ty&&>(_Val);
                     }
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
@@ -648,9 +661,9 @@ namespace ranges {
 // clang-format off
 template <class _Ty>
     requires _Dereferenceable<_Ty> && requires(_Ty& __t) {
-        { _STD ranges::iter_move(__t) } -> _Can_reference;
+        { _RANGES iter_move(__t) } -> _Can_reference;
     }
-using iter_rvalue_reference_t = decltype(_STD ranges::iter_move(_STD declval<_Ty&>()));
+using iter_rvalue_reference_t = decltype(_RANGES iter_move(_STD declval<_Ty&>()));
 
 // CONCEPT readable
 template <class _It>
@@ -841,10 +854,10 @@ namespace ranges {
 
         template <class _Xty, class _Yty>
         _NODISCARD constexpr iter_value_t<remove_reference_t<_Xty>> _Iter_exchange_move(
-            _Xty&& __x, _Yty&& __y) noexcept(noexcept(iter_value_t<remove_reference_t<_Xty>>(iter_move(__x)))) {
-            iter_value_t<remove_reference_t<_Xty>> __tmp(iter_move(__x));
-            *__x = iter_move(__y);
-            return __tmp;
+            _Xty&& _XVal, _Yty&& _YVal) noexcept(noexcept(iter_value_t<remove_reference_t<_Xty>>(iter_move(_XVal)))) {
+            iter_value_t<remove_reference_t<_Xty>> _Tmp(iter_move(_XVal));
+            *_XVal = iter_move(_YVal);
+            return _Tmp;
         }
 
         class _Cpo {
@@ -874,14 +887,14 @@ namespace ranges {
         public:
             template <class _Ty1, class _Ty2>
                 requires (_Choice<_Ty1, _Ty2>._Strategy != _St::_None)
-            constexpr void operator()(_Ty1&& __t1, _Ty2&& __t2) const noexcept(_Choice<_Ty1, _Ty2>._No_throw) {
+            constexpr void operator()(_Ty1&& _Val1, _Ty2&& _Val2) const noexcept(_Choice<_Ty1, _Ty2>._No_throw) {
                 if constexpr (_Choice<_Ty1, _Ty2>._Strategy == _St::_Custom) {
-                    iter_swap(static_cast<_Ty1&&>(__t1), static_cast<_Ty2&&>(__t2));
+                    iter_swap(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2));
                 } else if constexpr (_Choice<_Ty1, _Ty2>._Strategy == _St::_Swap) {
-                    swap(*static_cast<_Ty1&&>(__t1), *static_cast<_Ty2&&>(__t2));
+                    swap(*static_cast<_Ty1&&>(_Val1), *static_cast<_Ty2&&>(_Val2));
                 } else if constexpr (_Choice<_Ty1, _Ty2>._Strategy == _St::_Exchange) {
-                    *static_cast<_Ty1&&>(__t1) =
-                        _Iter_exchange_move(static_cast<_Ty1&&>(__t1), static_cast<_Ty2&&>(__t2));
+                    *static_cast<_Ty1&&>(_Val1) =
+                        _Iter_exchange_move(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2));
                 } else {
                     static_assert(_Always_false<_Ty1>, "should be unreachable");
                 }
@@ -894,6 +907,18 @@ namespace ranges {
         inline constexpr _Iter_swap::_Cpo iter_swap;
     }
 } // namespace ranges
+
+// ALIAS TEMPLATE _Iter_ref_t
+template <class _Iter>
+using _Iter_ref_t = iter_reference_t<_Iter>;
+
+// ALIAS TEMPLATE _Iter_value_t
+template <class _Iter>
+using _Iter_value_t = iter_value_t<_Iter>;
+
+// ALIAS TEMPLATE _Iter_diff_t
+template <class _Iter>
+using _Iter_diff_t = iter_difference_t<_Iter>;
 
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
 // STRUCT TEMPLATE iterator_traits
@@ -929,7 +954,6 @@ struct iterator_traits : _Iterator_traits_base<_Iter> {}; // get traits from ite
 
 template <class _Ty>
 struct iterator_traits<_Ty*> : _Iterator_traits_pointer_base<_Ty> {}; // get traits from pointer, if possible
-#endif // __cpp_lib_concepts
 
 // ALIAS TEMPLATE _Iter_ref_t
 template <class _Iter>
@@ -942,6 +966,7 @@ using _Iter_value_t = typename iterator_traits<_Iter>::value_type;
 // ALIAS TEMPLATE _Iter_diff_t
 template <class _Iter>
 using _Iter_diff_t = typename iterator_traits<_Iter>::difference_type;
+#endif // __cpp_lib_concepts
 
 // ALIAS TEMPLATE _Common_diff_t
 template <class... _Iters>
@@ -992,22 +1017,19 @@ constexpr void _Verify_range(const _Ty* const _First, const _Ty* const _Last) no
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
 template <class _Iter, class = void>
-struct _Allow_inheriting_unwrap : true_type {};
+_INLINE_VAR constexpr bool _Allow_inheriting_unwrap_v = true;
 
 template <class _Iter>
-struct _Allow_inheriting_unwrap<_Iter, enable_if_t<!is_same_v<_Iter, typename _Iter::_Prevent_inheriting_unwrap>>>
-    : false_type {};
+_INLINE_VAR constexpr bool _Allow_inheriting_unwrap_v<_Iter, void_t<typename _Iter::_Prevent_inheriting_unwrap>> =
+    is_same_v<_Iter, typename _Iter::_Prevent_inheriting_unwrap>;
 
 template <class _Iter, class _Sentinel = _Iter, class = void>
-struct _Range_verifiable : false_type {};
+_INLINE_VAR constexpr bool _Range_verifiable_v = false;
 
 template <class _Iter, class _Sentinel>
-struct _Range_verifiable<_Iter, _Sentinel,
-    void_t<decltype(_Verify_range(_STD declval<const _Iter&>(), _STD declval<const _Sentinel&>()))>>
-    : _Allow_inheriting_unwrap<_Iter>::type {};
-
-template <class _Iter, class _Sentinel = _Iter>
-_INLINE_VAR constexpr bool _Range_verifiable_v = _Range_verifiable<_Iter, _Sentinel>::value;
+_INLINE_VAR constexpr bool _Range_verifiable_v<_Iter, _Sentinel,
+    void_t<decltype(_Verify_range(_STD declval<const _Iter&>(), _STD declval<const _Sentinel&>()))>> =
+    _Allow_inheriting_unwrap_v<_Iter>;
 
 #if _HAS_IF_CONSTEXPR
 template <class _Iter, class _Sentinel>
@@ -1042,80 +1064,93 @@ constexpr void _Adl_verify_range(const _Iter& _First, const _Sentinel& _Last) {
 
 // FUNCTION TEMPLATE _Get_unwrapped
 template <class _Iter, class = void>
-struct _Unwrappable : false_type {};
+_INLINE_VAR constexpr bool _Unwrappable_v = false;
 
 template <class _Iter>
-struct _Unwrappable<_Iter, void_t<decltype(_STD declval<_Iter&>()._Seek_to(_STD declval<const _Iter&>()._Unwrapped()))>>
-    : _Allow_inheriting_unwrap<_Iter>::type {};
+_INLINE_VAR constexpr bool _Unwrappable_v<_Iter,
+    void_t<decltype(_STD declval<_Remove_cvref_t<_Iter>&>()._Seek_to(_STD declval<_Iter>()._Unwrapped()))>> =
+    _Allow_inheriting_unwrap_v<_Remove_cvref_t<_Iter>>;
 
+#if _HAS_IF_CONSTEXPR
 template <class _Iter>
-_INLINE_VAR constexpr bool _Unwrappable_v = _Unwrappable<_Iter>::value;
-
-template <class _Iter, enable_if_t<_Unwrappable_v<_Iter>, int> = 0>
-_NODISCARD constexpr auto _Get_unwrapped(const _Iter& _It) {
+_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) {
     // unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
-    return _It._Unwrapped();
+    if constexpr (is_pointer_v<decay_t<_Iter>>) { // special-case pointers and arrays
+        return _It + 0;
+    } else if constexpr (_Unwrappable_v<_Iter>) {
+        return static_cast<_Iter&&>(_It)._Unwrapped();
+    } else {
+        return static_cast<_Iter&&>(_It);
+    }
+}
+#else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
+template <class _Iter, enable_if_t<_Unwrappable_v<_Iter>, int> = 0>
+_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) {
+    // unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
+    return static_cast<_Iter&&>(_It)._Unwrapped();
 }
 
 template <class _Iter, enable_if_t<!_Unwrappable_v<_Iter>, int> = 0>
-_NODISCARD constexpr const _Iter& _Get_unwrapped(const _Iter& _It) {
+_NODISCARD constexpr _Iter&& _Get_unwrapped(_Iter&& _It) {
     // (don't) unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
-    return _It;
-}
-
-template <class _Iter, enable_if_t<!_Unwrappable_v<_Iter>, int> = 0>
-_NODISCARD constexpr const _Iter&& _Get_unwrapped(const _Iter&& _It) {
-    // (don't) unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
-    return static_cast<const _Iter&&>(_It);
+    return static_cast<_Iter&&>(_It);
 }
 
 template <class _Ty>
 _NODISCARD constexpr _Ty* _Get_unwrapped(_Ty* const _Ptr) { // special case already-unwrapped pointers
     return _Ptr;
 }
+#endif // _HAS_IF_CONSTEXPR
 
 template <class _Iter>
-using _Unwrapped_t = _Remove_cvref_t<decltype(_Get_unwrapped(_STD declval<const _Iter&>()))>;
+using _Unwrapped_t = _Remove_cvref_t<decltype(_Get_unwrapped(_STD declval<_Iter>()))>;
 
 // FUNCTION TEMPLATE _Get_unwrapped_unverified
 template <class _Iter, class = bool>
-struct _Do_unwrap_when_unverified : false_type {};
+_INLINE_VAR constexpr bool _Do_unwrap_when_unverified_v = false;
 
 template <class _Iter>
-struct _Do_unwrap_when_unverified<_Iter, decltype(static_cast<bool>(_Iter::_Unwrap_when_unverified))>
-    : bool_constant<static_cast<bool>(_Iter::_Unwrap_when_unverified)> {};
+_INLINE_VAR constexpr bool
+    _Do_unwrap_when_unverified_v<_Iter, decltype(static_cast<bool>(_Iter::_Unwrap_when_unverified))> =
+        static_cast<bool>(_Iter::_Unwrap_when_unverified);
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Do_unwrap_when_unverified_v = _Do_unwrap_when_unverified<_Iter>::value;
+_INLINE_VAR constexpr bool _Unwrappable_for_unverified_v =
+    _Unwrappable_v<_Iter>&& _Do_unwrap_when_unverified_v<_Remove_cvref_t<_Iter>>;
 
+#if _HAS_IF_CONSTEXPR
 template <class _Iter>
-_INLINE_VAR constexpr bool _Unwrappable_for_unverified_v = _Unwrappable_v<_Iter>&& _Do_unwrap_when_unverified_v<_Iter>;
-
-template <class _Iter, enable_if_t<_Unwrappable_for_unverified_v<_Iter>, int> = 0>
-_NODISCARD constexpr auto _Get_unwrapped_unverified(const _Iter& _It) {
+_NODISCARD constexpr decltype(auto) _Get_unwrapped_unverified(_Iter&& _It) {
     // unwrap an iterator not previously subjected to _Adl_verify_range
-    return _It._Unwrapped();
+    if constexpr (is_pointer_v<decay_t<_Iter>>) { // special-case pointers and arrays
+        return _It + 0;
+    } else if constexpr (_Unwrappable_for_unverified_v<_Iter>) {
+        return static_cast<_Iter&&>(_It)._Unwrapped();
+    } else {
+        return static_cast<_Iter&&>(_It);
+    }
+}
+#else // ^^^_HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
+template <class _Iter, enable_if_t<_Unwrappable_for_unverified_v<_Iter>, int> = 0>
+_NODISCARD constexpr decltype(auto) _Get_unwrapped_unverified(_Iter&& _It) {
+    // unwrap an iterator not previously subjected to _Adl_verify_range
+    return static_cast<_Iter&&>(_It)._Unwrapped();
 }
 
 template <class _Iter, enable_if_t<!_Unwrappable_for_unverified_v<_Iter>, int> = 0>
-_NODISCARD constexpr const _Iter& _Get_unwrapped_unverified(const _Iter& _It) {
+_NODISCARD constexpr _Iter&& _Get_unwrapped_unverified(_Iter&& _It) {
     // (don't) unwrap an iterator not previously subjected to _Adl_verify_range
-    return _It;
-}
-
-template <class _Iter, enable_if_t<!_Unwrappable_for_unverified_v<_Iter>, int> = 0>
-_NODISCARD constexpr const _Iter&& _Get_unwrapped_unverified(const _Iter&& _It) {
-    // (don't) unwrap an iterator not previously subjected to _Adl_verify_range
-    return static_cast<const _Iter&&>(_It);
+    return static_cast<_Iter&&>(_It);
 }
 
 template <class _Ty>
 _NODISCARD constexpr _Ty* _Get_unwrapped_unverified(_Ty* const _Ptr) { // special case already-unwrapped pointers
     return _Ptr;
 }
+#endif // _HAS_IF_CONSTEXPR
 
 template <class _Iter>
-using _Unwrapped_unverified_t = _Remove_cvref_t<decltype(_Get_unwrapped_unverified(_STD declval<const _Iter&>()))>;
+using _Unwrapped_unverified_t = _Remove_cvref_t<decltype(_Get_unwrapped_unverified(_STD declval<_Iter>()))>;
 
 // FUNCTION TEMPLATE _Get_unwrapped_n
 struct _Distance_unknown {
@@ -1125,28 +1160,55 @@ struct _Distance_unknown {
 };
 
 template <class _Diff>
-_INLINE_VAR constexpr _Diff _Max_possible_v = static_cast<_Diff>(static_cast<make_unsigned_t<_Diff>>(-1) >> 1);
+_INLINE_VAR constexpr auto _Max_possible_v = _Diff{static_cast<make_unsigned_t<_Diff>>(-1) >> 1};
 
 template <class _Diff>
-_INLINE_VAR constexpr _Diff _Min_possible_v = -_Max_possible_v<_Diff> - 1;
+_INLINE_VAR constexpr auto _Min_possible_v = _Diff{-_Max_possible_v<_Diff> - 1};
 
 template <class _Iter, class = void>
-struct _Offset_verifiable : false_type {};
+_INLINE_VAR constexpr bool _Offset_verifiable_v = false;
 
 template <class _Iter>
-struct _Offset_verifiable<_Iter, void_t<decltype(_STD declval<const _Iter&>()._Verify_offset(_Iter_diff_t<_Iter>{}))>>
-    : true_type {};
+_INLINE_VAR constexpr bool
+    _Offset_verifiable_v<_Iter, void_t<decltype(_STD declval<const _Iter&>()._Verify_offset(_Iter_diff_t<_Iter>{}))>> =
+        true;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Offset_verifiable_v = _Offset_verifiable<_Iter>::value;
+_INLINE_VAR constexpr bool _Unwrappable_for_offset_v =
+    _Unwrappable_v<_Iter>&& _Offset_verifiable_v<_Remove_cvref_t<_Iter>>;
 
-template <class _Iter>
-_INLINE_VAR constexpr bool _Unwrappable_for_offset_v = _Unwrappable_v<_Iter>&& _Offset_verifiable_v<_Iter>;
+#if _HAS_IF_CONSTEXPR
+template <class _Iter, class _Diff>
+_NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _Off) {
+    (void) _Off;
+    if constexpr (is_pointer_v<decay_t<_Iter>>) {
+        return _It + 0;
+    } else if constexpr (_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>) {
+        // ask an iterator to assert that the iterator moved _Off positions is valid, and unwrap
+        using _IDiff     = _Iter_diff_t<_Remove_cvref_t<_Iter>>;
+        using _CDiff     = common_type_t<_Diff, _IDiff>;
+        const auto _COff = static_cast<_CDiff>(_Off);
 
+        _STL_ASSERT(_COff <= static_cast<_CDiff>(_Max_possible_v<_IDiff>)
+                        && (is_unsigned_v<_Diff> || static_cast<_CDiff>(_Min_possible_v<_IDiff>) <= _COff),
+            "integer overflow");
+        (void) _COff;
+
+        _It._Verify_offset(static_cast<_IDiff>(_Off));
+        return static_cast<_Iter&&>(_It)._Unwrapped();
+    } else if constexpr (_Unwrappable_for_unverified_v<_Iter>) {
+        // iterator doesn't support offset-based asserts, or offset unknown; defer to unverified unwrap
+        return static_cast<_Iter&&>(_It)._Unwrapped();
+    } else {
+        // pass through iterator that doesn't participate in checking
+        return static_cast<_Iter&&>(_It);
+    }
+}
+#else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
 template <class _Iter, class _Diff, enable_if_t<_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>, int> = 0>
-_NODISCARD constexpr auto _Get_unwrapped_n(const _Iter& _It, const _Diff _Off) {
+_NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _Off) {
     // ask an iterator to assert that the iterator moved _Off positions is valid, and unwrap
-    using _IDiff     = _Iter_diff_t<_Iter>;
+    using _IDiff     = _Iter_diff_t<_Remove_cvref_t<_Iter>>;
     using _CDiff     = common_type_t<_Diff, _IDiff>;
     const auto _COff = static_cast<_CDiff>(_Off);
 
@@ -1156,7 +1218,7 @@ _NODISCARD constexpr auto _Get_unwrapped_n(const _Iter& _It, const _Diff _Off) {
     (void) _COff;
 
     _It._Verify_offset(static_cast<_IDiff>(_Off));
-    return _It._Unwrapped();
+    return static_cast<_Iter&&>(_It)._Unwrapped();
 }
 
 template <class _Iter, class _Diff,
@@ -1164,9 +1226,9 @@ template <class _Iter, class _Diff,
         _Unwrappable_for_unverified_v<_Iter> //
             && ((!_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>) || is_same_v<_Diff, _Distance_unknown>),
         int> = 0>
-_NODISCARD constexpr auto _Get_unwrapped_n(const _Iter& _It, _Diff) {
+_NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, _Diff) {
     // iterator doesn't support offset-based asserts, or offset unknown; defer to unverified unwrap
-    return _It._Unwrapped();
+    return static_cast<_Iter&&>(_It)._Unwrapped();
 }
 
 template <class _Iter, class _Diff,
@@ -1174,65 +1236,55 @@ template <class _Iter, class _Diff,
         !_Unwrappable_for_unverified_v<_Iter> //
             && ((!_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>) || is_same_v<_Diff, _Distance_unknown>),
         int> = 0>
-_NODISCARD constexpr const _Iter& _Get_unwrapped_n(const _Iter& _It, _Diff) {
-    // pass through lvalue iterator that doesn't participate in checking
-    return _It;
-}
-
-template <class _Iter, class _Diff,
-    enable_if_t<
-        !_Unwrappable_for_unverified_v<_Iter> //
-            && ((!_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>) || is_same_v<_Diff, _Distance_unknown>),
-        int> = 0>
-_NODISCARD constexpr const _Iter&& _Get_unwrapped_n(const _Iter&& _It, _Diff) {
-    // pass through rvalue iterator that doesn't participate in checking
-    return static_cast<const _Iter&&>(_It);
+_NODISCARD constexpr _Iter&& _Get_unwrapped_n(_Iter&& _It, _Diff) {
+    // pass through iterator that doesn't participate in checking
+    return static_cast<_Iter&&>(_It);
 }
 
 template <class _Ty, class _Diff, enable_if_t<is_same_v<_Diff, _Distance_unknown> || is_integral_v<_Diff>, int> = 0>
 _NODISCARD constexpr _Ty* _Get_unwrapped_n(_Ty* const _Src, _Diff) {
     return _Src;
 }
+#endif // _HAS_IF_CONSTEXPR
 
 template <class _Iter>
-using _Unwrapped_n_t = _Remove_cvref_t<decltype(_Get_unwrapped_n(_STD declval<const _Iter&>(), _Iter_diff_t<_Iter>{}))>;
+using _Unwrapped_n_t =
+    _Remove_cvref_t<decltype(_Get_unwrapped_n(_STD declval<_Iter>(), _Iter_diff_t<_Remove_cvref_t<_Iter>>{}))>;
 
 // FUNCTION TEMPLATE _Seek_wrapped
 template <class _Iter, class _UIter, class = void>
-struct _Wrapped_seekable : false_type {};
+_INLINE_VAR constexpr bool _Wrapped_seekable_v = false;
 
 template <class _Iter, class _UIter>
-struct _Wrapped_seekable<_Iter, _UIter,
-    void_t<decltype(_STD declval<_Iter&>()._Seek_to(_STD declval<const _UIter&>()))>> : true_type {};
-
-template <class _Iter, class _UIter>
-_INLINE_VAR constexpr bool _Wrapped_seekable_v = _Wrapped_seekable<_Iter, _UIter>::value;
+_INLINE_VAR constexpr bool
+    _Wrapped_seekable_v<_Iter, _UIter, void_t<decltype(_STD declval<_Iter&>()._Seek_to(_STD declval<_UIter>()))>> =
+        true;
 
 #if _HAS_IF_CONSTEXPR
 template <class _Iter, class _UIter>
-constexpr void _Seek_wrapped(_Iter& _It, const _UIter& _UIt) {
+constexpr void _Seek_wrapped(_Iter& _It, _UIter&& _UIt) {
     if constexpr (_Wrapped_seekable_v<_Iter, _UIter>) {
-        _It._Seek_to(_UIt);
+        _It._Seek_to(static_cast<_UIter&&>(_UIt));
     } else {
-        _It = _UIt;
+        _It = static_cast<_UIter&&>(_UIt);
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
 template <class _Iter, class _UIter, enable_if_t<_Wrapped_seekable_v<_Iter, _UIter>, int> = 0>
-constexpr void _Seek_wrapped(_Iter& _It, const _UIter& _UIt) {
-    _It._Seek_to(_UIt);
+constexpr void _Seek_wrapped(_Iter& _It, _UIter&& _UIt) {
+    _It._Seek_to(static_cast<_UIter&&>(_UIt));
 }
 
 template <class _Iter, class _UIter, enable_if_t<!_Wrapped_seekable_v<_Iter, _UIter>, int> = 0>
-constexpr void _Seek_wrapped(_Iter& _It, const _UIter& _UIt) {
-    _It = _UIt;
+constexpr void _Seek_wrapped(_Iter& _It, _UIter&& _UIt) {
+    _It = static_cast<_UIter&&>(_UIt);
 }
-#endif // _HAS_IF_CONSTEXPR
 
 template <class _Ty>
 constexpr void _Seek_wrapped(_Ty*& _It, _Ty* const _UIt) {
     _It = _UIt;
 }
+#endif // _HAS_IF_CONSTEXPR
 
 #if _HAS_CXX17
 // STRUCT TEMPLATE _Is_allocator
@@ -1519,18 +1571,25 @@ _CONSTEXPR17 void advance(_InIt& _Where, _Diff _Off) { // increment iterator by 
     if constexpr (_Is_random_iter_v<_InIt>) {
         _Where += _Off;
     } else {
-        if constexpr (is_signed_v<_Diff>) {
-            if constexpr (_Is_bidi_iter_v<_InIt>) {
-                for (; _Off < 0; ++_Off) {
-                    --_Where;
-                }
-            } else {
-                _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
+        if constexpr (is_signed_v<_Diff> && !_Is_bidi_iter_v<_InIt>) {
+            _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
+        }
+
+        auto&& _UWhere              = _Get_unwrapped_n(_STD move(_Where), _Off);
+        constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
+
+        if constexpr (is_signed_v<_Diff> && _Is_bidi_iter_v<_InIt>) {
+            for (; _Off < 0; ++_Off) {
+                --_UWhere;
             }
         }
 
         for (; 0 < _Off; --_Off) {
-            ++_Where;
+            ++_UWhere;
+        }
+
+        if constexpr (_Need_rewrap) {
+            _Seek_wrapped(_Where, _STD move(_UWhere));
         }
     }
 }
@@ -1539,23 +1598,38 @@ template <class _InIt, class _Diff>
 _CONSTEXPR17 void _Advance1(_InIt& _Where, _Diff _Off, input_iterator_tag) {
     // increment iterator by offset, input iterators
     _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
+
+    auto&& _UWhere              = _Get_unwrapped_n(_STD move(_Where), _Off);
+    constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
+
     for (; 0 < _Off; --_Off) {
-        ++_Where;
+        ++_UWhere;
+    }
+
+    if (_Need_rewrap) {
+        _Seek_wrapped(_Where, _STD move(_UWhere));
     }
 }
 
 template <class _BidIt, class _Diff>
 _CONSTEXPR17 void _Advance1(_BidIt& _Where, _Diff _Off, bidirectional_iterator_tag) {
     // increment iterator by offset, bidirectional iterators
+    auto&& _UWhere              = _Get_unwrapped_n(_STD move(_Where), _Off);
+    constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
+
     for (; 0 < _Off; --_Off) {
-        ++_Where;
+        ++_UWhere;
     }
 
     // the following warning is triggered if _Diff is unsigned
 #pragma warning(suppress : 6294) // Ill-defined for-loop: initial condition does not satisfy test.
                                  // Loop body not executed.
     for (; _Off < 0; ++_Off) {
-        --_Where;
+        --_UWhere;
+    }
+
+    if (_Need_rewrap) {
+        _Seek_wrapped(_Where, _STD move(_UWhere));
     }
 }
 
@@ -1755,9 +1829,9 @@ public:
         current._Verify_offset(-_Off);
     }
 
-    template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<_BidIt2>, int> = 0>
-    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<_BidIt2>> _Unwrapped() const {
-        return static_cast<reverse_iterator<_Unwrapped_t<_BidIt2>>>(current._Unwrapped());
+    template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<const _BidIt2&>, int> = 0>
+    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const {
+        return static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped());
     }
 
     static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_BidIt>;
@@ -2049,13 +2123,13 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
-                    return __t;
+                    return _Val;
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return __t.begin();
+                    return _Val.begin();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return begin(static_cast<_Ty&&>(__t));
+                    return begin(static_cast<_Ty&&>(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "Should be unreachable");
                 }
@@ -2064,7 +2138,7 @@ namespace ranges {
         };
     } // namespace _Begin
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Begin::_Cpo begin;
     }
 
@@ -2082,13 +2156,13 @@ namespace ranges {
         // clang-format off
         template <class _Ty>
         concept _Has_member = requires(_Ty& __t) {
-            { _Fake_decay_copy(__t.end()) } -> sentinel_for<decltype(begin(__t))>;
+            { _Fake_decay_copy(__t.end()) } -> sentinel_for<decltype(_RANGES begin(__t))>;
         };
 
         template <class _Ty>
         concept _Has_ADL = requires(_Ty&& __t) {
             { _Fake_decay_copy(end(static_cast<_Ty&&>(__t))) } ->
-                sentinel_for<decltype(begin(static_cast<_Ty&&>(__t)))>;
+                sentinel_for<decltype(_RANGES begin(static_cast<_Ty&&>(__t)))>;
         };
         // clang-format on
 
@@ -2120,13 +2194,13 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
-                    return __t + extent_v<remove_reference_t<_Ty>>;
+                    return _Val + extent_v<remove_reference_t<_Ty>>;
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return __t.end();
+                    return _Val.end();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return end(static_cast<_Ty&&>(__t));
+                    return end(static_cast<_Ty&&>(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2135,15 +2209,15 @@ namespace ranges {
         };
     } // namespace _End
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _End::_Cpo end;
     }
 
     // CONCEPT ranges::range
     template <class _Rng>
     concept _Range_impl = requires(_Rng&& __r) {
-        begin(static_cast<_Rng&&>(__r));
-        end(static_cast<_Rng&&>(__r));
+        _RANGES begin(static_cast<_Rng&&>(__r));
+        _RANGES end(static_cast<_Rng&&>(__r));
     };
 
     template <class _Rng>
@@ -2157,11 +2231,11 @@ namespace ranges {
 
     // ALIAS TEMPLATE ranges::iterator_t
     template <range _Rng>
-    using iterator_t = decltype(begin(_STD declval<_Rng&>()));
+    using iterator_t = decltype(_RANGES begin(_STD declval<_Rng&>()));
 
     // ALIAS TEMPLATE ranges::sentinel_t
     template <range _Rng>
-    using sentinel_t = decltype(end(_STD declval<_Rng&>()));
+    using sentinel_t = decltype(_RANGES end(_STD declval<_Rng&>()));
 
     // ALIAS TEMPLATE ranges::range_difference_t
     template <class _Rng>
@@ -2183,15 +2257,15 @@ namespace ranges {
     struct _Cbegin_fn {
         // clang-format off
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
-        _NODISCARD constexpr auto operator()(_Ty&& __t) const
-            noexcept(noexcept(begin(static_cast<_CTy&&>(__t))))
-            requires requires { begin(static_cast<_CTy&&>(__t)); } {
-            return begin(static_cast<_CTy&&>(__t));
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES begin(static_cast<_CTy&&>(_Val))))
+            requires requires { _RANGES begin(static_cast<_CTy&&>(_Val)); } {
+            return _RANGES begin(static_cast<_CTy&&>(_Val));
         }
         // clang-format on
     };
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Cbegin_fn cbegin;
     }
 
@@ -2199,15 +2273,15 @@ namespace ranges {
     struct _Cend_fn {
         // clang-format off
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
-        _NODISCARD constexpr auto operator()(_Ty&& __t) const
-            noexcept(noexcept(end(static_cast<_CTy&&>(__t))))
-            requires requires { end(static_cast<_CTy&&>(__t)); } {
-            return end(static_cast<_CTy&&>(__t));
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES end(static_cast<_CTy&&>(_Val))))
+            requires requires { _RANGES end(static_cast<_CTy&&>(_Val)); } {
+            return _RANGES end(static_cast<_CTy&&>(_Val));
         }
         // clang-format on
     };
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Cend_fn cend;
     }
 
@@ -2235,8 +2309,8 @@ namespace ranges {
 
         template <class _Ty>
         concept _Can_make_reverse = requires(_Ty&& __t) {
-            { begin(static_cast<_Ty&&>(__t)) } -> bidirectional_iterator;
-            { end(static_cast<_Ty&&>(__t)) } -> same_as<decltype(begin(static_cast<_Ty&&>(__t)))>;
+            { _RANGES begin(static_cast<_Ty&&>(__t)) } -> bidirectional_iterator;
+            { _RANGES end(static_cast<_Ty&&>(__t)) } -> same_as<decltype(_RANGES begin(static_cast<_Ty&&>(__t)))>;
         };
         // clang-format on
 
@@ -2251,7 +2325,7 @@ namespace ranges {
                 } else if constexpr (_Has_ADL<_Ty>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty>())))};
                 } else if constexpr (_Can_make_reverse<_Ty>) {
-                    return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(end(_STD declval<_Ty>())))};
+                    return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2264,13 +2338,13 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return __t.rbegin();
+                    return _Val.rbegin();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return rbegin(static_cast<_Ty&&>(__t));
+                    return rbegin(static_cast<_Ty&&>(_Val));
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Make_reverse) {
-                    return _STD make_reverse_iterator(end(static_cast<_Ty&&>(__t)));
+                    return _STD make_reverse_iterator(_RANGES end(static_cast<_Ty&&>(_Val)));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2279,7 +2353,7 @@ namespace ranges {
         };
     } // namespace _Rbegin
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Rbegin::_Cpo rbegin;
     }
 
@@ -2297,24 +2371,24 @@ namespace ranges {
         // clang-format off
         template <class _Ty>
         concept _Can_rbegin = requires(_Ty&& __t) {
-            rbegin(static_cast<_Ty&&>(__t));
+            _RANGES rbegin(static_cast<_Ty&&>(__t));
         };
 
         template <class _Ty>
         concept _Has_member = is_lvalue_reference_v<_Ty> && requires(_Ty& __t) {
-            { _Fake_decay_copy(__t.rend()) } -> sentinel_for<decltype(rbegin(__t))>;
+            { _Fake_decay_copy(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
         concept _Has_ADL = requires(_Ty&& __t) {
             { _Fake_decay_copy(rend(static_cast<_Ty&&>(__t))) } ->
-                sentinel_for<decltype(rbegin(static_cast<_Ty&&>(__t)))>;
+                sentinel_for<decltype(_RANGES rbegin(static_cast<_Ty&&>(__t)))>;
         };
 
         template <class _Ty>
         concept _Can_make_reverse = requires(_Ty&& __t) {
-            { begin(static_cast<_Ty&&>(__t)) } -> bidirectional_iterator;
-            { end(static_cast<_Ty&&>(__t)) } -> same_as<decltype(begin(static_cast<_Ty&&>(__t)))>;
+            { _RANGES begin(static_cast<_Ty&&>(__t)) } -> bidirectional_iterator;
+            { _RANGES end(static_cast<_Ty&&>(__t)) } -> same_as<decltype(_RANGES begin(static_cast<_Ty&&>(__t)))>;
         };
         // clang-format on
 
@@ -2330,7 +2404,8 @@ namespace ranges {
                     } else if constexpr (_Has_ADL<_Ty>) {
                         return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty>())))};
                     } else if constexpr (_Can_make_reverse<_Ty>) {
-                        return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(begin(_STD declval<_Ty>())))};
+                        return {_St::_Make_reverse,
+                            noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty>())))};
                     }
                 }
 
@@ -2344,13 +2419,13 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return __t.rend();
+                    return _Val.rend();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return rend(static_cast<_Ty&&>(__t));
+                    return rend(static_cast<_Ty&&>(_Val));
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Make_reverse) {
-                    return _STD make_reverse_iterator(begin(static_cast<_Ty&&>(__t)));
+                    return _STD make_reverse_iterator(_RANGES begin(static_cast<_Ty&&>(_Val)));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2359,7 +2434,7 @@ namespace ranges {
         };
     } // namespace _Rend
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Rend::_Cpo rend;
     }
 
@@ -2367,15 +2442,15 @@ namespace ranges {
     struct _Crbegin_fn {
         // clang-format off
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
-        _NODISCARD constexpr auto operator()(_Ty&& __t) const
-            noexcept(noexcept(rbegin(static_cast<_CTy&&>(__t))))
-            requires requires { rbegin(static_cast<_CTy&&>(__t)); } {
-            return rbegin(static_cast<_CTy&&>(__t));
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES rbegin(static_cast<_CTy&&>(_Val))))
+            requires requires { _RANGES rbegin(static_cast<_CTy&&>(_Val)); } {
+            return _RANGES rbegin(static_cast<_CTy&&>(_Val));
         }
         // clang-format on
     };
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Crbegin_fn crbegin;
     }
 
@@ -2383,15 +2458,15 @@ namespace ranges {
     struct _Crend_fn {
         // clang-format off
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
-        _NODISCARD constexpr auto operator()(_Ty&& __t) const
-            noexcept(noexcept(rend(static_cast<_CTy&&>(__t))))
-            requires requires { rend(static_cast<_CTy&&>(__t)); } {
-            return rend(static_cast<_CTy&&>(__t));
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES rend(static_cast<_CTy&&>(_Val))))
+            requires requires { _RANGES rend(static_cast<_CTy&&>(_Val)); } {
+            return _RANGES rend(static_cast<_CTy&&>(_Val));
         }
         // clang-format on
     };
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Crend_fn crend;
     }
 
@@ -2421,8 +2496,8 @@ namespace ranges {
 
         template <class _Ty>
         concept _Can_difference = requires(_Ty&& __t) {
-            { begin(__t) } -> forward_iterator;
-            { end(__t) } -> sized_sentinel_for<decltype(begin(__t))>;
+            { _RANGES begin(__t) } -> forward_iterator;
+            { _RANGES end(__t) } -> sized_sentinel_for<decltype(_RANGES begin(__t))>;
         };
         // clang-format on
 
@@ -2440,7 +2515,8 @@ namespace ranges {
                 } else if constexpr (_Has_ADL<_Ty, _UnCV>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(size(_STD declval<_Ty>())))};
                 } else if constexpr (_Can_difference<_Ty>) {
-                    return {_St::_Subtract, noexcept(end(_STD declval<_Ty&>()) - begin(_STD declval<_Ty&>()))};
+                    return {_St::_Subtract,
+                        noexcept(_RANGES end(_STD declval<_Ty&>()) - _RANGES begin(_STD declval<_Ty&>()))};
                 } else {
                     return {_St::_None};
                 }
@@ -2453,15 +2529,15 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()([[maybe_unused]] _Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr auto operator()([[maybe_unused]] _Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
                     return extent_v<remove_cvref_t<_Ty>>;
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return static_cast<_Ty&&>(__t).size();
+                    return static_cast<_Ty&&>(_Val).size();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return size(static_cast<_Ty&&>(__t));
+                    return size(static_cast<_Ty&&>(_Val));
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Subtract) {
-                    const auto _Delta = end(__t) - begin(__t);
+                    const auto _Delta = _RANGES end(_Val) - _RANGES begin(_Val);
                     return static_cast<make_unsigned_t<remove_cv_t<decltype(_Delta)>>>(_Delta);
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
@@ -2471,7 +2547,7 @@ namespace ranges {
         };
     } // namespace _Size
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Size::_Cpo size;
     }
 
@@ -2485,13 +2561,13 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_size = requires(_Ty&& __t) {
-            size(static_cast<_Ty&&>(__t));
+            _RANGES size(static_cast<_Ty&&>(__t));
         };
 
         template <class _Ty>
         concept _Can_begin_end = requires(_Ty&& __t) {
-            { begin(__t) } -> forward_iterator;
-            end(__t);
+            { _RANGES begin(__t) } -> forward_iterator;
+            _RANGES end(__t);
         };
         // clang-format on
 
@@ -2504,10 +2580,10 @@ namespace ranges {
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(static_cast<bool>(_STD declval<_Ty>().empty()))};
                 } else if constexpr (_Has_size<_Ty>) {
-                    return {_St::_Size, noexcept(size(_STD declval<_Ty>()))};
+                    return {_St::_Size, noexcept(_RANGES size(_STD declval<_Ty>()))};
                 } else if constexpr (_Can_begin_end<_Ty>) {
-                    constexpr auto _Nothrow =
-                        noexcept(static_cast<bool>(begin(_STD declval<_Ty&>()) == end(_STD declval<_Ty&>())));
+                    constexpr auto _Nothrow = noexcept(
+                        static_cast<bool>(_RANGES begin(_STD declval<_Ty&>()) == _RANGES end(_STD declval<_Ty&>())));
                     return {_St::_Compare, _Nothrow};
                 } else {
                     return {_St::_None};
@@ -2521,13 +2597,13 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr bool operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr bool operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return static_cast<bool>(static_cast<_Ty&&>(__t).empty());
+                    return static_cast<bool>(static_cast<_Ty&&>(_Val).empty());
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Size) {
-                    return size(static_cast<_Ty&&>(__t)) == 0;
+                    return _RANGES size(static_cast<_Ty&&>(_Val)) == 0;
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Compare) {
-                    return static_cast<bool>(begin(__t) == end(__t));
+                    return static_cast<bool>(_RANGES begin(_Val) == _RANGES end(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2536,7 +2612,7 @@ namespace ranges {
         };
     } // namespace _Empty
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Empty::_Cpo empty;
     }
 
@@ -2553,7 +2629,7 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_contiguous_iterator = requires(_Ty&& __t) {
-            { begin(static_cast<_Ty&&>(__t)) } -> contiguous_iterator;
+            { _RANGES begin(static_cast<_Ty&&>(__t)) } -> contiguous_iterator;
         };
         // clang-format on
 
@@ -2566,7 +2642,7 @@ namespace ranges {
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_STD declval<_Ty&>().data())};
                 } else if constexpr (_Has_contiguous_iterator<_Ty>) {
-                    return {_St::_Address, noexcept(_STD to_address(begin(_STD declval<_Ty>())))};
+                    return {_St::_Address, noexcept(_STD to_address(_RANGES begin(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2579,11 +2655,11 @@ namespace ranges {
             // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& __t) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return __t.data();
+                    return _Val.data();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Address) {
-                    return _STD to_address(begin(static_cast<_Ty&&>(__t)));
+                    return _STD to_address(_RANGES begin(static_cast<_Ty&&>(_Val)));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2592,7 +2668,7 @@ namespace ranges {
         };
     } // namespace _Data
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Data::_Cpo data;
     }
 
@@ -2600,15 +2676,15 @@ namespace ranges {
     struct _Cdata_fn {
         // clang-format off
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
-        _NODISCARD constexpr auto operator()(_Ty&& __t) const
-            noexcept(noexcept(data(static_cast<_CTy&&>(__t))))
-            requires requires { data(static_cast<_CTy&&>(__t)); } {
-            return data(static_cast<_CTy&&>(__t));
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES data(static_cast<_CTy&&>(_Val))))
+            requires requires { _RANGES data(static_cast<_CTy&&>(_Val)); } {
+            return _RANGES data(static_cast<_CTy&&>(_Val));
         }
         // clang-format on
     };
 
-    inline namespace __cpos {
+    inline namespace _Cpos {
         inline constexpr _Cdata_fn cdata;
     }
 
@@ -2619,7 +2695,7 @@ namespace ranges {
 #if 0 // TRANSITION, LWG-3264
         && !disable_sized_range<remove_cvref_t<_Rng>>
 #endif // TRANSITION, LWG-3264
-        && requires(_Rng& __r) { size(__r); };
+        && requires(_Rng& __r) { _RANGES size(__r); };
     // clang-format on
 
     // STRUCT ranges::view_base
@@ -2668,9 +2744,223 @@ namespace ranges {
     // CONCEPT ranges::contiguous_range
     template <class _Rng>
     concept contiguous_range = range<_Rng> && contiguous_iterator<iterator_t<_Rng>> && requires(_Rng& __r) {
-        { data(__r) } -> same_as<add_pointer_t<range_reference_t<_Rng>>>;
+        { _RANGES data(__r) } -> same_as<add_pointer_t<range_reference_t<_Rng>>>;
     };
     // clang-format on
+
+    // CLASS ranges::_Not_quite_object
+    class _Not_quite_object {
+    public:
+        // Some overload sets in the library have the property that their constituent function templates are not visible
+        // to argument-dependent name lookup (ADL) and that they inhibit ADL when found via unqualified name lookup.
+        // This property allows these overload sets to be implemented as function objects. We derive such function
+        // objects from this type to remove some typical object-ish behaviors which helps users avoid depending on their
+        // non-specified object-ness.
+
+        struct _Construct_tag {};
+
+        _Not_quite_object() = delete;
+
+        constexpr explicit _Not_quite_object(_Construct_tag) noexcept {}
+
+        _Not_quite_object(const _Not_quite_object&) = delete;
+        _Not_quite_object& operator=(const _Not_quite_object&) = delete;
+
+        void operator&() const = delete;
+
+    protected:
+        ~_Not_quite_object() = default;
+    };
+
+    // CLASS ranges::_Advance_fn
+    class _Advance_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        template <input_or_output_iterator _It>
+        constexpr void operator()(_It& _Where, iter_difference_t<_It> _Off) const {
+            if constexpr (random_access_iterator<_It>) {
+                _Where += _Off;
+            } else {
+                if constexpr (!bidirectional_iterator<_It>) {
+                    _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
+                }
+
+                auto&& _UWhere              = _Get_unwrapped_n(_STD move(_Where), _Off);
+                constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
+
+                if constexpr (bidirectional_iterator<_It>) {
+                    for (; _Off < 0; ++_Off) {
+                        --_UWhere;
+                    }
+                }
+
+                for (; _Off > 0; --_Off) {
+                    ++_UWhere;
+                }
+
+                if constexpr (_Need_rewrap) {
+                    _Seek_wrapped(_Where, _STD move(_UWhere));
+                }
+            }
+        }
+
+        template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+        constexpr void operator()(_It& _Where, _Se _Last) const {
+            if constexpr (assignable_from<_It&, _Se>) {
+                _Where = static_cast<_Se&&>(_Last);
+            } else if constexpr (sized_sentinel_for<_Se, _It>) {
+                (*this)(_Where, _Last - _Where);
+            } else {
+                _Adl_verify_range(_Where, _Last);
+
+                auto&& _UWhere              = _Get_unwrapped(static_cast<_It&&>(_Where));
+                constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped(static_cast<_It&&>(_Where)))>;
+                auto&& _ULast               = _Get_unwrapped(static_cast<_Se&&>(_Last));
+
+                while (_UWhere != _ULast) {
+                    ++_UWhere;
+                }
+
+                if constexpr (_Need_rewrap) {
+                    _Seek_wrapped(_Where, static_cast<_It&&>(_UWhere));
+                }
+            }
+        }
+
+        template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+        constexpr iter_difference_t<_It> operator()(_It& _Where, iter_difference_t<_It> _Off, _Se _Last) const {
+            if constexpr (sized_sentinel_for<_Se, _It>) {
+                const iter_difference_t<_It> _Delta = _Last - _Where;
+                if ((_Off < 0 && _Off <= _Delta) || (_Off > 0 && _Off >= _Delta)) {
+                    if constexpr (assignable_from<_It&, _Se>) {
+                        _Where = static_cast<_Se&&>(_Last);
+                    } else {
+                        (*this)(_Where, _Delta);
+                    }
+                    return _Off - _Delta;
+                }
+
+                (*this)(_Where, _Off);
+                return 0;
+            } else {
+                // performance note: develop unwrapping technology for (i, n, s)?
+                if constexpr (bidirectional_iterator<_It>) {
+                    for (; _Off < 0 && _Where != _Last; ++_Off) {
+                        --_Where;
+                    }
+                } else {
+                    _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
+                }
+
+                for (; _Off > 0 && _Where != _Last; --_Off) {
+                    ++_Where;
+                }
+
+                return _Off;
+            }
+        }
+    };
+
+    // VARIABLE ranges::advance
+    inline constexpr _Advance_fn advance{_Not_quite_object::_Construct_tag{}};
+
+    // CLASS ranges::_Distance_fn
+    class _Distance_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+        _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last) const {
+            if constexpr (sized_sentinel_for<_Se, _It>) {
+                return _Last - _First;
+            } else {
+                _Adl_verify_range(_First, _Last);
+                auto _UFirst                  = _Get_unwrapped(static_cast<_It&&>(_First));
+                const auto _ULast             = _Get_unwrapped(static_cast<_Se&&>(_Last));
+                iter_difference_t<_It> _Count = 0;
+                for (; _UFirst != _ULast; ++_UFirst) {
+                    ++_Count;
+                }
+
+                return _Count;
+            }
+        }
+
+        template <range _Rng>
+        _NODISCARD constexpr range_difference_t<_Rng> operator()(_Rng&& _Val) const {
+            if constexpr (sized_range<_Rng>) {
+                return static_cast<range_difference_t<_Rng>>(_RANGES size(_Val));
+            } else {
+                return (*this)(_RANGES begin(_Val), _RANGES end(_Val));
+            }
+        }
+    };
+
+    // VARIABLE ranges::distance
+    inline constexpr _Distance_fn distance{_Not_quite_object::_Construct_tag{}};
+
+    // CLASS ranges::_Next_fn
+    class _Next_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        template <input_or_output_iterator _It>
+        _NODISCARD constexpr _It operator()(_It _Where) const {
+            ++_Where;
+            return _Where;
+        }
+
+        template <input_or_output_iterator _It>
+        _NODISCARD constexpr _It operator()(_It _Where, const iter_difference_t<_It> _Off) const {
+            _RANGES advance(_Where, _Off);
+            return _Where;
+        }
+
+        template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+        _NODISCARD constexpr _It operator()(_It _Where, _Se _Last) const {
+            _RANGES advance(_Where, static_cast<_Se&&>(_Last));
+            return _Where;
+        }
+
+        template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+        _NODISCARD constexpr _It operator()(_It _Where, const iter_difference_t<_It> _Off, _Se _Last) const {
+            _RANGES advance(_Where, _Off, static_cast<_Se&&>(_Last));
+            return _Where;
+        }
+    };
+
+    // VARIABLE ranges::next
+    inline constexpr _Next_fn next{_Not_quite_object::_Construct_tag{}};
+
+    // CLASS ranges::_Prev_fn
+    class _Prev_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        template <bidirectional_iterator _It>
+        _NODISCARD constexpr _It operator()(_It _Where) const {
+            --_Where;
+            return _Where;
+        }
+
+        template <bidirectional_iterator _It>
+        _NODISCARD constexpr _It operator()(_It _Where, const iter_difference_t<_It> _Off) const {
+            _STL_ASSERT(_Off != _Min_possible_v<iter_difference_t<_It>>, "integer overflow");
+            _RANGES advance(_Where, -_Off);
+            return _Where;
+        }
+
+        template <bidirectional_iterator _It>
+        _NODISCARD constexpr _It operator()(_It _Where, const iter_difference_t<_It> _Off, _It _Last) const {
+            _STL_ASSERT(_Off != _Min_possible_v<iter_difference_t<_It>>, "integer overflow");
+            _RANGES advance(_Where, -_Off, static_cast<_It&&>(_Last));
+            return _Where;
+        }
+    };
+
+    // VARIABLE ranges::prev
+    inline constexpr _Prev_fn prev{_Not_quite_object::_Construct_tag{}};
 } // namespace ranges
 #endif // __cpp_lib_concepts
 
@@ -3186,9 +3476,9 @@ public:
         current._Verify_offset(_Off);
     }
 
-    template <class _Iter2 = iterator_type, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
-    _NODISCARD constexpr move_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() const {
-        return static_cast<move_iterator<_Unwrapped_t<_Iter2>>>(current._Unwrapped());
+    template <class _Iter2 = iterator_type, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
+    _NODISCARD constexpr move_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const {
+        return static_cast<move_iterator<_Unwrapped_t<const _Iter2&>>>(current._Unwrapped());
     }
 
     static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<iterator_type>;
@@ -3249,6 +3539,40 @@ template <class _Iter>
 _NODISCARD _CONSTEXPR17 move_iterator<_Iter> make_move_iterator(_Iter _It) { // make move_iterator from iterator
     return move_iterator<_Iter>(_It);
 }
+
+#ifdef __cpp_lib_concepts
+// STRUCT default_sentinel_t
+struct default_sentinel_t {};
+
+// VARIABLE default_sentinel
+inline constexpr default_sentinel_t default_sentinel{};
+
+// STRUCT unreachable_sentinel_t
+struct unreachable_sentinel_t {
+    template <weakly_incrementable _Winc>
+    _NODISCARD friend constexpr bool operator==(unreachable_sentinel_t, const _Winc&) noexcept {
+        return false;
+    }
+#if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
+    template <weakly_incrementable _Winc>
+    _NODISCARD friend constexpr bool operator==(const _Winc&, unreachable_sentinel_t) noexcept {
+        return false;
+    }
+
+    template <weakly_incrementable _Winc>
+    _NODISCARD friend constexpr bool operator!=(unreachable_sentinel_t, const _Winc&) noexcept {
+        return true;
+    }
+    template <weakly_incrementable _Winc>
+    _NODISCARD friend constexpr bool operator!=(const _Winc&, unreachable_sentinel_t) noexcept {
+        return true;
+    }
+#endif // !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
+};
+
+// VARIABLE unreachable_sentinel
+inline constexpr unreachable_sentinel_t unreachable_sentinel{};
+#endif // __cpp_lib_concepts
 
 // FUNCTION TEMPLATE copy
 template <class _InIt, class _OutIt>
@@ -3735,17 +4059,16 @@ struct _Is_character_or_byte<byte> : true_type {};
 
 // _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill
 // clang-format off
-template <class _FwdIt, class _Ty,
-    class _Value_type = _Iter_value_t<_FwdIt>,
-    class _Raw_ty = _Unwrap_enum_t<_Ty>,
-    class _Raw_value_type = _Unwrap_enum_t<_Value_type>>
+template <class _FwdIt, class _Ty, bool = is_pointer_v<_FwdIt>>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe =
     conjunction_v<
-        is_pointer<_FwdIt>,
         disjunction<
-            conjunction<_Is_character_or_byte<_Raw_ty>, _Is_character_or_byte<_Raw_value_type>>,
-            conjunction<is_same<bool, _Raw_ty>, is_same<bool, _Raw_value_type>>>,
+            conjunction<_Is_character_or_byte<_Unwrap_enum_t<_Ty>>, _Is_character_or_byte<_Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>,
+            conjunction<is_same<bool, _Unwrap_enum_t<_Ty>>, is_same<bool, _Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>>,
         is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
+
+template <class _FwdIt, class _Ty>
+_INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
 // clang-format on
 
 #if _HAS_IF_CONSTEXPR
@@ -3754,7 +4077,7 @@ void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) { // copy _V
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    if constexpr (_Fill_memset_is_safe<_Unwrapped_t<_FwdIt>, _Ty>) {
+    if constexpr (_Fill_memset_is_safe<decltype(_UFirst), _Ty>) {
         _CSTD memset(_UFirst, static_cast<unsigned char>(_Val), static_cast<size_t>(_ULast - _UFirst));
     } else {
         for (; _UFirst != _ULast; ++_UFirst) {
@@ -3781,7 +4104,7 @@ template <class _FwdIt, class _Ty>
 void fill(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) { // copy _Val through [_First, _Last)
     _Adl_verify_range(_First, _Last);
     _Fill_unchecked1(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val,
-        bool_constant<_Fill_memset_is_safe<_Unwrapped_t<_FwdIt>, _Ty>>{});
+        bool_constant<_Fill_memset_is_safe<_Unwrapped_t<const _FwdIt&>, _Ty>>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1005,6 +1005,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #define _STD_BEGIN namespace std {
 #define _STD_END   }
 #define _STD       ::std::
+#define _RANGES    ::std::ranges::
 
 // We use the stdext (standard extension) namespace to contain extensions that are not part of the current standard
 #define _STDEXT_BEGIN namespace stdext {


### PR DESCRIPTION
# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
