### PR TITLE
Adopt LWG-3264 unconditionally (#511)

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2637,11 +2637,9 @@ namespace ranges {
     // clang-format off
     // CONCEPT ranges::sized_range
     template <class _Rng>
-    concept sized_range = range<_Rng>
-#if 0 // TRANSITION, LWG-3264
-        && !disable_sized_range<remove_cvref_t<_Rng>>
-#endif // TRANSITION, LWG-3264
-        && requires(_Rng& __r) { _RANGES size(__r); };
+    concept sized_range = range<_Rng> && requires(_Rng& __r) {
+        _RANGES size(__r);
+    };
     // clang-format on
 
     // STRUCT ranges::view_base


### PR DESCRIPTION
Fixes #536.

# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
