### PR TITLE
enable_view<T> now defaults to derived_from<T, view_base> (#588)

### DIFF
--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -383,16 +383,6 @@ namespace stdext {
 _STD_BEGIN
 using _STDEXT hash_multiset;
 using _STDEXT hash_set;
-
-#ifdef __cpp_lib_concepts
-namespace ranges {
-    template <class _Kty, class _Tr, class _Alloc>
-    inline constexpr bool enable_view<_STDEXT hash_set<_Kty, _Tr, _Alloc>> = false;
-
-    template <class _Kty, class _Tr, class _Alloc>
-    inline constexpr bool enable_view<_STDEXT hash_multiset<_Kty, _Tr, _Alloc>> = false;
-} // namespace ranges
-#endif // __cpp_lib_concepts
 _STD_END
 
 #pragma pop_macro("new")

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -938,13 +938,6 @@ basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, 
 template <class _BidIt, class _Allocator = allocator<sub_match<_BidIt>>>
 class match_results;
 
-#ifdef __cpp_lib_concepts
-namespace ranges {
-    template <class _BidIt, class _Allocator>
-    inline constexpr bool enable_view<match_results<_BidIt, _Allocator>> = false;
-} // namespace ranges
-#endif // __cpp_lib_concepts
-
 template <class _BidIt, class _Alloc, class _InIt, class _OutIt>
 _OutIt _Format_default(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _InIt _First, _InIt _Last,
     regex_constants::match_flag_type _Flags = regex_constants::format_default);

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -336,16 +336,6 @@ namespace pmr {
     using multiset = _STD multiset<_Kty, _Pr, polymorphic_allocator<_Kty>>;
 } // namespace pmr
 #endif // _HAS_CXX17
-
-#ifdef __cpp_lib_concepts
-namespace ranges {
-    template <class _Kty, class _Pr, class _Alloc>
-    inline constexpr bool enable_view<set<_Kty, _Pr, _Alloc>> = false;
-
-    template <class _Kty, class _Pr, class _Alloc>
-    inline constexpr bool enable_view<multiset<_Kty, _Pr, _Alloc>> = false;
-} // namespace ranges
-#endif // __cpp_lib_concepts
 _STD_END
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -260,6 +260,8 @@ class span;
 #ifdef __cpp_lib_concepts
 namespace ranges {
     template <class _Ty, size_t _Extent>
+    inline constexpr bool enable_view<span<_Ty, _Extent>> = _Extent == 0 || _Extent == dynamic_extent;
+    template <class _Ty, size_t _Extent>
     inline constexpr bool enable_borrowed_range<span<_Ty, _Extent>> = true;
 } // namespace ranges
 

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -609,16 +609,6 @@ namespace pmr {
     using unordered_multiset = _STD unordered_multiset<_Kty, _Hasher, _Keyeq, polymorphic_allocator<_Kty>>;
 } // namespace pmr
 #endif // _HAS_CXX17
-
-#ifdef __cpp_lib_concepts
-namespace ranges {
-    template <class _Kty, class _Hasher, class _Keyeq, class _Alloc>
-    inline constexpr bool enable_view<unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>> = false;
-
-    template <class _Kty, class _Hasher, class _Keyeq, class _Alloc>
-    inline constexpr bool enable_view<unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>> = false;
-} // namespace ranges
-#endif // __cpp_lib_concepts
 _STD_END
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1576,6 +1576,8 @@ private:
 #ifdef __cpp_lib_concepts
 namespace ranges {
     template <class _Elem, class _Traits>
+    inline constexpr bool enable_view<basic_string_view<_Elem, _Traits>> = true;
+    template <class _Elem, class _Traits>
     inline constexpr bool enable_borrowed_range<basic_string_view<_Elem, _Traits>> = true;
 } // namespace ranges
 #endif // __cpp_lib_concepts

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2772,19 +2772,8 @@ namespace ranges {
     struct view_base {};
 
     // VARIABLE TEMPLATE ranges::enable_view
-    // clang-format off
     template <class _Ty>
-    concept _Enable_view_impl = derived_from<_Ty, view_base> || !range<_Ty> || !range<const _Ty>
-        || same_as<range_reference_t<_Ty>, range_reference_t<const _Ty>>;
-    // clang-format on
-
-    template <class _Ty>
-    inline constexpr bool enable_view = _Enable_view_impl<_Ty>;
-
-    template <class _Ty>
-    inline constexpr bool enable_view<initializer_list<_Ty>> = false;
-
-    // enable_view specializations for (unordered_)?(multi)?set and match_results are in the corresponding headers.
+    inline constexpr bool enable_view = derived_from<_Ty, view_base>;
 
     // clang-format off
     // CONCEPT ranges::view

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1633,12 +1633,12 @@ namespace exhaustive_size_and_view_test {
     STATIC_ASSERT(test<mutable_unsized_range const, false, CI, S>());
     STATIC_ASSERT(test<mutable_unsized_range const&, false, CI, S>());
 
-    STATIC_ASSERT(test<mutable_only_no_size_range, true, I, S>());
+    STATIC_ASSERT(test<mutable_only_no_size_range, false, I, S>());
     STATIC_ASSERT(test<mutable_only_no_size_range&, false, I, S>());
     STATIC_ASSERT(test<mutable_only_no_size_range const>());
     STATIC_ASSERT(test<mutable_only_no_size_range const&>());
 
-    STATIC_ASSERT(test<immutable_unsized_range, true, CI, S>());
+    STATIC_ASSERT(test<immutable_unsized_range, false, CI, S>());
     STATIC_ASSERT(test<immutable_unsized_range&, false, CI, S>());
     STATIC_ASSERT(test<immutable_unsized_range const, false, CI, S>());
     STATIC_ASSERT(test<immutable_unsized_range const&, false, CI, S>());
@@ -1648,12 +1648,12 @@ namespace exhaustive_size_and_view_test {
     STATIC_ASSERT(test<mutable_sized_range const, false, CI, UC>());
     STATIC_ASSERT(test<mutable_sized_range const&, false, CI, UC>());
 
-    STATIC_ASSERT(test<mutable_only_sized_range, true, I, UC>());
+    STATIC_ASSERT(test<mutable_only_sized_range, false, I, UC>());
     STATIC_ASSERT(test<mutable_only_sized_range&, false, I, UC>());
     STATIC_ASSERT(test<mutable_only_sized_range const>());
     STATIC_ASSERT(test<mutable_only_sized_range const&>());
 
-    STATIC_ASSERT(test<immutable_sized_range, true, CI, UC>());
+    STATIC_ASSERT(test<immutable_sized_range, false, CI, UC>());
     STATIC_ASSERT(test<immutable_sized_range&, false, CI, UC>());
     STATIC_ASSERT(test<immutable_sized_range const, false, CI, UC>());
     STATIC_ASSERT(test<immutable_sized_range const&, false, CI, UC>());
@@ -1663,12 +1663,12 @@ namespace exhaustive_size_and_view_test {
     STATIC_ASSERT(test<mutable_badsized_range const, false, CI, S>());
     STATIC_ASSERT(test<mutable_badsized_range const&, false, CI, S>());
 
-    STATIC_ASSERT(test<mutable_only_badsized_range, true, I, S>());
+    STATIC_ASSERT(test<mutable_only_badsized_range, false, I, S>());
     STATIC_ASSERT(test<mutable_only_badsized_range&, false, I, S>());
     STATIC_ASSERT(test<mutable_only_badsized_range const>());
     STATIC_ASSERT(test<mutable_only_badsized_range const&>());
 
-    STATIC_ASSERT(test<immutable_badsized_range, true, CI, S>());
+    STATIC_ASSERT(test<immutable_badsized_range, false, CI, S>());
     STATIC_ASSERT(test<immutable_badsized_range&, false, CI, S>());
     STATIC_ASSERT(test<immutable_badsized_range const, false, CI, S>());
     STATIC_ASSERT(test<immutable_badsized_range const&, false, CI, S>());
@@ -1719,7 +1719,7 @@ constexpr ranges::iterator_t<R> complicated_algorithm(R&& r) {
 }
 
 template <class T>
-struct array_view {
+struct array_view : ranges::view_base {
     T* first_;
     std::size_t n_;
 


### PR DESCRIPTION
Implements LWG-3326 "`enable_view` has false positives".

Fixes #543.

# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
